### PR TITLE
Change hyphens into em dashes for separators

### DIFF
--- a/src/main/lastfm.js
+++ b/src/main/lastfm.js
@@ -95,7 +95,7 @@ const lfm = {
                 this.authenticate();
             }
         } else {
-            return console.log('[LastFM] Did not add ', attributes.name , '-' , lfm.filterArtistName(attributes.artistName), 'because now playing a other song.');
+            return console.log('[LastFM] Did not add ', attributes.name , '—' , lfm.filterArtistName(attributes.artistName), 'because now playing a other song.');
         }
     },
 

--- a/src/renderer/index_old.html
+++ b/src/renderer/index_old.html
@@ -64,7 +64,7 @@
                                     {{ mk.nowPlayingItem["attributes"]["name"] }}
                                 </div>
                                 <div class="song-artist">
-                                    {{ mk.nowPlayingItem["attributes"]["artistName"] }} - {{
+                                    {{ mk.nowPlayingItem["attributes"]["artistName"] }} — {{
                                     mk.nowPlayingItem["attributes"]["albumName"] }}
                                 </div>
                                 <div class="song-progress">
@@ -560,7 +560,7 @@
                     <template v-if="item.attributes.artistName">
                         {{ item.attributes.artistName }}
                         <template v-if="item.attributes.albumName">
-                            - {{ item.attributes.albumName }}
+                            — {{ item.attributes.albumName }}
                         </template>
                     </template>
                 </div>

--- a/src/renderer/views/components/fullscreen.ejs
+++ b/src/renderer/views/components/fullscreen.ejs
@@ -33,7 +33,7 @@
                                 </div>
                                 <div class="song-artist item-navigate" style="display: inline-block;"
                                      @click="app.getNowPlayingItemDetailed('album')">
-                                    {{ (app.mk.nowPlayingItem["attributes"]["albumName"]) ? (" - " +
+                                    {{ (app.mk.nowPlayingItem["attributes"]["albumName"]) ? (" — " +
                                     app.mk.nowPlayingItem["attributes"]["albumName"]) : "" }}
                                 </div>
                             </div>

--- a/src/renderer/views/components/mediaitem-list-item.ejs
+++ b/src/renderer/views/components/mediaitem-list-item.ejs
@@ -39,7 +39,7 @@
                              @click="app.searchAndNavigate(item,'artist')">
                             {{ item.attributes.artistName }}
                         </div>
-                        <template v-if="item.attributes.albumName">&nbsp;-&nbsp;</template>
+                        <template v-if="item.attributes.albumName">&nbsp;—&nbsp;</template>
                         <template v-if="item.attributes.albumName">
                             <div class="artist item-navigate text-overflow-elipsis"
                                  @click="app.searchAndNavigate(item,'album')">

--- a/src/renderer/views/components/queue-item.ejs
+++ b/src/renderer/views/components/queue-item.ejs
@@ -19,7 +19,7 @@
                             <div class="artist item-navigate text-overflow-elipsis" @click="app.searchAndNavigate(item,'artist')">
                                 {{ item.attributes.artistName }}
                             </div>
-                            <template v-if="item.attributes.albumName">&nbsp;-&nbsp;</template>
+                            <template v-if="item.attributes.albumName">&nbsp;—&nbsp;</template>
                             <template v-if="item.attributes.albumName">
                                 <div class="artist item-navigate text-overflow-elipsis" @click="app.searchAndNavigate(item,'album')">
                                 {{ item.attributes.albumName }}

--- a/src/renderer/views/components/queue.ejs
+++ b/src/renderer/views/components/queue.ejs
@@ -25,7 +25,7 @@
                             </div>
                             <div class="col queue-info">
                                 <div class="queue-title text-overflow-elipsis">{{ queueItem.item.attributes.name }}</div>
-                                <div class="queue-subtitle text-overflow-elipsis">{{ queueItem.item.attributes.albumName }} - {{ queueItem.item.attributes.artistName }}</div>
+                                <div class="queue-subtitle text-overflow-elipsis">{{ queueItem.item.attributes.albumName }} — {{ queueItem.item.attributes.artistName }}</div>
                             </div>
                         </div>
                     </div>

--- a/src/renderer/views/main.ejs
+++ b/src/renderer/views/main.ejs
@@ -93,7 +93,7 @@
                                         </div>
                                         <div class="song-artist item-navigate" style="display: inline-block;"
                                              @click="getNowPlayingItemDetailed('album')">
-                                            <div class="separator" style="display: inline-block;">{{"-"}}</div>
+                                            <div class="separator" style="display: inline-block;">{{"—"}}</div>
                                             {{(mk.nowPlayingItem["attributes"]["albumName"]) ?
                                             (mk.nowPlayingItem["attributes"]["albumName"]) : "" }}
                                         </div>


### PR DESCRIPTION
TL;DR: Apple uses it so why not?

# Disclaimer

I don't know JavaScript. I have built my changes and tested things out but I am not sure if I did everything correctly. Please advice if I have done any damages.

# The PR
## Right now:

Apple Music's iOS app, Web Player and iTunes all uses the U+2014 EM DASH: — symbol to separate artist with the album.
Cider is currently using a normal hyphen (U+002D HYPHEN-MINUS: -) to do this.

**Apple Music Web Player (beta)**
![image](https://user-images.githubusercontent.com/32032824/149669283-1d21fa4e-01e1-4ff0-8aca-59ef57c8e0ee.png)

**Cider, as of commit ffc55b6b64813c58404ef762bca285b9cf567f3e**
![image](https://user-images.githubusercontent.com/32032824/149669436-a8ed1b4f-38a7-48e5-9bc8-86aa0c50483c.png)


## Code changes:

I have replaced most, if not all, of the hyphens separating artists and albums with em dashes. I may be missing some of them, so this PR is a draft state right now.

*Note:* Code editors and monospace fonts will shorten the em dash (longer than full-width) to full-width length, so it will look exactly the same

**Cider, after changes**
![image](https://user-images.githubusercontent.com/32032824/149669491-3ea5a06c-c1fa-4521-8123-e05992c56270.png)


## Does it work?

I mean it builds and plays music fine, so ¯\\\_\(ツ\)\_\/¯