### PR TITLE
Minor UX Improvements: Context Menu Position and Album Hitbox

### DIFF
--- a/src/renderer/views/components/mediaitem-square.ejs
+++ b/src/renderer/views/components/mediaitem-square.ejs
@@ -2,8 +2,7 @@
     <div tabindex="0"
          class="cd-mediaitem-square" :class="getClasses()" @contextmenu="contextMenu"
          v-observe-visibility="{callback: visibilityChanged}"
-         :style="{'--spcolor': getBgColor()}"
-         @click.self='app.routeView(item)'>
+         :style="{'--spcolor': getBgColor()}">
         <template v-if="isVisible">
             <div class="artwork-container">
                 <div class="artwork" @click='app.routeView(item)'>

--- a/src/renderer/views/components/menu-panel.ejs
+++ b/src/renderer/views/components/menu-panel.ejs
@@ -72,10 +72,10 @@
                     style["top"] = this.event.clientY + "px";
                     // make sure the menu panel isnt off the screen
                     if (this.event.clientX + this.size[0] > window.innerWidth) {
-                        style["left"] = (window.innerWidth - this.size[0]) + "px";
+                        style["left"] = (this.event.clientX - this.size[0]) + "px";
                     }
                     if (this.event.clientY + this.size[1] > window.innerHeight) {
-                        style["top"] = (window.innerHeight - this.size[1]) + "px";
+                        style["top"] = (this.event.clientY - this.size[1]) + "px";
                     }
                 }
                 return style


### PR DESCRIPTION
## Context Menu Position
In order to keep the context menu inside the window when it would otherwise be out of bounds, the application snapped it to as far as it could go without surpassing the window's width and height. However, this positioning doesn't feel natural. Using Discord's context menu as an example, the context menu should align in the opposite direction of the mouse if it will go out of bounds.

**Before, red arrow indicating the point where user opens the context menu.**
![image](https://user-images.githubusercontent.com/34148795/150041076-c5e30bef-827c-4fca-82f7-6b58a38e6bf3.png)
 **After, red arrow indicating the point where user opens the context menu.**
![image](https://user-images.githubusercontent.com/34148795/150041198-8545971b-fe44-4ddd-99c1-a188b249c05b.png)
**Discord, as an example. Mouse is indicated at green arrow.**
![image](https://user-images.githubusercontent.com/34148795/150041417-4ec71c7c-bba1-457c-89d9-0606a2ee51e5.png)

## Album Hitbox
The album display, `mediaitem-square`, has been causing me issues with accidental inputs, activating their click event despite clicking outside of their shape. I believe the hitbox/clickbox of the element should include the album art and album title, and not the element's margin.

**Before, the area where clicking would activate the element's click event.**
![image](https://user-images.githubusercontent.com/34148795/150042089-782e1a88-faa9-462f-9a5c-00cc2609131b.png)
**After, the area where clicking should activate the element's click event.**
![image](https://user-images.githubusercontent.com/34148795/150042132-6b2a27fd-6cc2-46da-ab5a-4698372d2532.png)

## Conclusion
Sorry for the extensive write-up. Feel free to take one change, both changes, or neither.
