### PR TITLE
Center Web Remote Landscape

### DIFF
--- a/src/web-remote/style.css
+++ b/src/web-remote/style.css
@@ -1051,9 +1051,8 @@ input[type=range].web-slider::-webkit-slider-runnable-track {
     .player-panel {
         display: flex;
         flex-direction: row;
-    }
-    .player_top {
-        width: 100%;
+        justify-content: center;
+        padding: 40px;
     }
     .player_bottom {
         display: flex;
@@ -1061,12 +1060,14 @@ input[type=range].web-slider::-webkit-slider-runnable-track {
         align-items: center;
         flex-direction: column;
         width: 100%;
-        margin: 0 auto;
+        max-width: 50vw;
+        margin: 0;
+        padding: 0 16px;
     }
     .media-artwork {
         width: 45vw;
         height: 45vw;
-        margin: 60px;
+        margin: 0;
     }
     .player-song-title {
         font-size: 2em;


### PR DESCRIPTION
## Explanation
Cider's WIP web-remote isn't centered properly on a landscape view. Some CSS has been changed in order to properly size and center the elements in the main view. The screenshots below show the fix in action with a few different screen sizes. All are rendered using Firefox on Windows.

## Screenshots
![image](https://user-images.githubusercontent.com/34148795/150656687-39a1939b-813c-40b2-846a-a2a2b1dd623a.png)
![image](https://user-images.githubusercontent.com/34148795/150656693-46e143ee-0fdc-480b-a3f8-446b106311ae.png)
![image](https://user-images.githubusercontent.com/34148795/150656740-251bb960-fa37-446b-8654-5b49c1a630bb.png)