### PR TITLE
i18n: Changed English (UK) into a main language rather than a fun language

### DIFF
--- a/src/i18n/en_GB.jsonc
+++ b/src/i18n/en_GB.jsonc
@@ -1,10 +1,16 @@
 {
-        // i18n Info
-    "i18n.languageName": "English (UK) (Roadman)",        // name of language in native language
-    "i18n.languageNameEnglish": "English (UK)", // name of language in English
-    "i18n.category": "fun", // main = real language, fun = fun community languages
-    "i18n.authors": "Core", // Authors, if you contribute to this file feel free to add your name seperated with a space
-    "date.format": "${d} ${m}, ${y}",
-
-    "home.friendsListeningTo": "Mandems Listening To"
+  // i18n Info
+  "i18n.languageName": "English (UK)", // name of language in native language
+  "i18n.languageNameEnglish": "English (UK)", // name of language in English
+  "i18n.category": "main", // main = real language, fun = fun community languages
+  "i18n.authors": "inalone", // Authors, if you contribute to this file feel free to add your name seperated with a space
+  "date.format": "${d} ${m}, ${y}",
+  // translations
+  "term.equalizer": "Equalizer",
+  "settings.option.audio.enableAdvancedFunctionality.description": "Enabling AudioContext functionality will allow for extended audio features like Audio Normalisation , Equalisers and Visualisers, however on some systems this may cause stuttering in audio tracks.",
+  "settings.option.audio.enableAdvancedFunctionality.audioNormalization": "Audio Normalisation", // Toggle
+  "settings.option.audio.enableAdvancedFunctionality.audioNormalization.description": "Normalises peak volume for individual tracks to create a more uniform listening experience.",
+  "settings.option.audio.enableAdvancedFunctionality.audioSpatialization": "Audio Spatialisation", // Toggle
+  "settings.option.audio.enableAdvancedFunctionality.audioSpatialization.description": "Spatialise audio and make audio more 3-dimensional (note: This is not Dolby Atmos)",
+  "spatial.notTurnedOn": "Audio Spatialisation is disabled. To use, please enable it first."
 }

--- a/src/i18n/en_GB.jsonc
+++ b/src/i18n/en_GB.jsonc
@@ -6,7 +6,7 @@
   "i18n.authors": "inalone", // Authors, if you contribute to this file feel free to add your name seperated with a space
   "date.format": "${d} ${m}, ${y}",
   // translations
-  "term.equalizer": "Equalizer",
+  "term.equalizer": "Equaliser",
   "settings.option.audio.enableAdvancedFunctionality.description": "Enabling AudioContext functionality will allow for extended audio features like Audio Normalisation , Equalisers and Visualisers, however on some systems this may cause stuttering in audio tracks.",
   "settings.option.audio.enableAdvancedFunctionality.audioNormalization": "Audio Normalisation", // Toggle
   "settings.option.audio.enableAdvancedFunctionality.audioNormalization.description": "Normalises peak volume for individual tracks to create a more uniform listening experience.",

--- a/src/i18n/en_GB.jsonc
+++ b/src/i18n/en_GB.jsonc
@@ -3,7 +3,7 @@
   "i18n.languageName": "English (UK)", // name of language in native language
   "i18n.languageNameEnglish": "English (UK)", // name of language in English
   "i18n.category": "main", // main = real language, fun = fun community languages
-  "i18n.authors": "inalone", // Authors, if you contribute to this file feel free to add your name seperated with a space
+  "i18n.authors": "Core inalone", // Authors, if you contribute to this file feel free to add your name seperated with a space
   "date.format": "${d} ${m}, ${y}",
   // translations
   "term.equalizer": "Equaliser",

--- a/src/i18n/en_GB.jsonc
+++ b/src/i18n/en_GB.jsonc
@@ -3,7 +3,7 @@
   "i18n.languageName": "English (UK)", // name of language in native language
   "i18n.languageNameEnglish": "English (UK)", // name of language in English
   "i18n.category": "main", // main = real language, fun = fun community languages
-  "i18n.authors": "Core inalone", // Authors, if you contribute to this file feel free to add your name seperated with a space
+  "i18n.authors": "Core, inalone", // Authors, if you contribute to this file feel free to add your name seperated with a space
   "date.format": "${d} ${m}, ${y}",
   // translations
   "term.equalizer": "Equaliser",


### PR DESCRIPTION
This PR changes English (UK) to reflect British English, with 'izer' and 'ization' being 'iser' and 'isation' respectively.