### PR TITLE
Fix "TypeError: plugin is not a constructor" when trying to load plugin from user path.

### DIFF
--- a/src/main/base/plugins.ts
+++ b/src/main/base/plugins.ts
@@ -33,7 +33,7 @@ export class Plugins {
         if (fs.existsSync(this.userPluginsPath)) {
             fs.readdirSync(this.userPluginsPath).forEach(file => {
                 if (file.endsWith('.ts') || file.endsWith('.js')) {
-                    const plugin = require(path.join(this.userPluginsPath, file)).default;
+                    const plugin = require(path.join(this.userPluginsPath, file));
                     file = file.replace('.ts', '').replace('.js', '');
                     if (plugins[file] || plugin in plugins) {
                         console.log(`[${plugin.name}] Plugin already loaded / Duplicate Class Name`);


### PR DESCRIPTION
This fixes loading plugins when they're placed in `%APPDATA%\Cider\plugins`.
This probably needs more testing, I've only used Cider on a Windows machine.