### PR TITLE
Updated the term show (important note in ext desc)

### DIFF
--- a/src/i18n/hu_HU.jsonc
+++ b/src/i18n/hu_HU.jsonc
@@ -196,7 +196,7 @@
   // Waiting on Core for moving plugin to app.ts
   "action.tray.minimize": "Kicsinyítés a tálcára",
   "action.tray.quit": "Kilépés",
-  "action.tray.show": "Megjelenítés",
+  "action.tray.show": "A következő megjelenítése:",
 
   // Settings - General
   "settings.header.general": "Általános",


### PR DESCRIPTION
IMPORTANT NOTE: The term "show" in Hungarian is "megjelenítés" and the word shall be conjugated, in which case the "Cider" word shall be placed before the term ("Show Cider" -> "Cider megjelenítése"). And in the translation file only the term "Show" can be translated, so in this case I could only solve this problem by writing "A következő megjelenítése: Cider" which is a translation of "Show this: Cider" which is not the best translation but with this issue it cannot be translated any better.