### PR TITLE
Update german translation

### DIFF
--- a/src/i18n/de_DE.jsonc
+++ b/src/i18n/de_DE.jsonc
@@ -50,7 +50,7 @@
   "term.createNewPlaylist": "Neue Playlist erstellen",
   "term.createNewPlaylistFolder": "Neuen Playlist-Ordner erstellen",
   "term.deletePlaylist": "Bist du sicher, dass du diese Playlist löschen willst?",
-  "term.play": "Play",
+  "term.play": "Abspielen",
   "term.pause": "Pause",
   "term.previous": "Zurück",
   "term.next": "Weiter",


### PR DESCRIPTION
Admittedly, "Play" does not feel right when next to all the other German words in an Album menu.
![grafik](https://user-images.githubusercontent.com/49114741/153265917-ba965b43-5b57-47c0-8bf7-b3d4b1f664a3.png)

In the original iTunes App, it also says "Abspielen" instead of "Play".
