### PR TITLE
Fix windows auto update

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,7 +150,8 @@
       "perMachine": false,
       "allowToChangeInstallationDirectory": true,
       "license": "LICENSE",
-      "deleteAppDataOnUninstall": true
+      "deleteAppDataOnUninstall": true,
+      "artifactName": "${productName}-Setup-${version}.${ext}"
     },
     "pkg": {
       "installLocation": "/Applications",


### PR DESCRIPTION
Windows exe file name is different from latest.yml, casing 404 error.
`Error: Cannot download "https://416-429851205-gh.circle-artifacts.com/0/%7E/Cider/dist/artifacts/Cider-Setup-1.1.416.exe.blockmap", status 404: Not Found`
Proposed change: rename the exe file to match the latest.yml