### PR TITLE
Also copy blockmap for partial download

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,7 @@ jobs:
               mv ~/Cider/dist/*.AppImage ~/Cider/dist/artifacts
               mv ~/Cider/dist/*.snap ~/Cider/dist/artifacts
               mv ~/Cider/dist/*.yml ~/Cider/dist/artifacts
+              mv ~/Cider/dist/*.blockmap ~/Cider/dist/artifacts
       - store_artifacts:
           path: ~/Cider/dist/artifacts
           


### PR DESCRIPTION
```
[2022-02-15 17:28:30.126] [error] Cannot download differentially, fallback to full download: Error: Cannot download "https://478-429851205-gh.circle-artifacts.com/0/%7E/Cider/dist/artifacts/Cider-Setup-1.1.428.exe.blockmap", status 404: Not Found
    at ClientRequest.<anonymous> (C:\Program Files\Cider\resources\app.asar\node_modules\builder-util-runtime\src\httpExecutor.ts:288:11)
    at ClientRequest.emit (node:events:394:28)
    at ClientRequest.emit (node:domain:475:12)
    at SimpleURLLoaderWrapper.<anonymous> (node:electron/js2c/browser_init:105:6829)
    at SimpleURLLoaderWrapper.emit (node:events:394:28)
    at SimpleURLLoaderWrapper.emit (node:domain:475:12)```