### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -2335,7 +2335,7 @@ const app = new Vue({
             let richsync = [];
             const lang = app.cfg.lyrics.mxm_language //  translation language
             function revisedRandId() {
-                return Math.random().toString(36).replace(/[^a-z]+/g, '').substr(2, 10);
+                return Math.random().toString(36).replace(/[^a-z]+/g, '').slice(2, 10);
             }
 
             /* get token */
@@ -3280,7 +3280,7 @@ const app = new Vue({
         },
         async nowPlayingContextMenu(event) {
             // function revisedRandId() {
-            //     return Math.random().toString(36).replace(/[^a-z]+/g, '').substr(2, 10);
+            //     return Math.random().toString(36).replace(/[^a-z]+/g, '').slice(2, 10);
             // }
             let self = this
             let data_type = this.mk.nowPlayingItem.playParams.kind

--- a/src/renderer/views/components/mediaitem-square-sp.ejs
+++ b/src/renderer/views/components/mediaitem-square-sp.ejs
@@ -90,7 +90,7 @@
         },
         methods: {
             revisedRandId() {
-                return Math.random().toString(36).replace(/[^a-z]+/g, '').substr(2, 10);
+                return Math.random().toString(36).replace(/[^a-z]+/g, '').slice(2, 10);
             },
             async isInLibrary() {
                 if (this.item.type && !this.item.type.includes("library")) {

--- a/src/renderer/views/components/mediaitem-square.ejs
+++ b/src/renderer/views/components/mediaitem-square.ejs
@@ -140,7 +140,7 @@
                 }
             },
             revisedRandId() {
-                return Math.random().toString(36).replace(/[^a-z]+/g, '').substr(2, 10);
+                return Math.random().toString(36).replace(/[^a-z]+/g, '').slice(2, 10);
             },
             async isInLibrary() {
                 if (this.item.type && !this.item.type.includes("library")) {

--- a/src/web-remote/views/components/mediaitem-square.ejs
+++ b/src/web-remote/views/components/mediaitem-square.ejs
@@ -153,7 +153,7 @@
                 }
             },
             revisedRandId() {
-                return Math.random().toString(36).replace(/[^a-z]+/g, '').substr(2, 10);
+                return Math.random().toString(36).replace(/[^a-z]+/g, '').slice(2, 10);
             },
             async isInLibrary() {
                 if (this.item.type && !this.item.type.includes("library")) {


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.