### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/src/main/base/browserwindow.ts
+++ b/src/main/base/browserwindow.ts
@@ -695,7 +695,7 @@ export class BrowserWindow {
 
             let latestbranchjson = await latestbranch.json()
             let base_url = latestbranchjson[0].url
-            base_url = base_url.substr(0, base_url.lastIndexOf('/'))
+            base_url = base_url.substring(0, base_url.lastIndexOf('/'))
 
             const options: any = {
                 provider: 'generic',

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -2497,7 +2497,7 @@ const app = new Vue({
             let richsync = [];
             const lang = app.cfg.lyrics.mxm_language //  translation language
             function revisedRandId() {
-                return Math.random().toString(36).replace(/[^a-z]+/g, '').substr(2, 10);
+                return Math.random().toString(36).replace(/[^a-z]+/g, '').slice(2, 10);
             }
 
             /* get token */

--- a/src/renderer/views/components/mediaitem-square.ejs
+++ b/src/renderer/views/components/mediaitem-square.ejs
@@ -145,7 +145,7 @@
                 }
             },
             revisedRandId() {
-                return Math.random().toString(36).replace(/[^a-z]+/g, '').substr(2, 10);
+                return Math.random().toString(36).replace(/[^a-z]+/g, '').slice(2, 10);
             },
             async isInLibrary() {
                 if (this.item.type && !this.item.type.includes("library")) {

--- a/src/web-remote/views/components/mediaitem-square.ejs
+++ b/src/web-remote/views/components/mediaitem-square.ejs
@@ -153,7 +153,7 @@
                 }
             },
             revisedRandId() {
-                return Math.random().toString(36).replace(/[^a-z]+/g, '').substr(2, 10);
+                return Math.random().toString(36).replace(/[^a-z]+/g, '').slice(2, 10);
             },
             async isInLibrary() {
                 if (this.item.type && !this.item.type.includes("library")) {


### PR DESCRIPTION
First I like to apologize for not using the correct target branch in the first PR. I didn't even check the auto selected one on the GitHub Desktop UI.

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) or [String.prototype.substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) which work similarily but aren't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.