### PR TITLE
last.fm: fix call to nowPlayingItemDidChangeLastFM

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -74,7 +74,7 @@ ipcMain.on('nowPlayingItemDidChange', (_event, attributes) => {
 });
 
 ipcMain.on('nowPlayingItemDidChangeLastFM', (_event, attributes) => {
-    CiderPlug.callPlugin('lastfm', 'nowPlayingItemDidChangeLastFM', attributes);
+    CiderPlug.callPlugin('lastfm.js', 'nowPlayingItemDidChangeLastFM', attributes);
 })
 
 app.on('before-quit', () => {

--- a/src/main/plugins/lastfm.ts
+++ b/src/main/plugins/lastfm.ts
@@ -254,15 +254,6 @@ export default class LastFMPlugin {
     }
 
     /**
-     * Runs on playback State Change
-     * @param attributes Music Attributes (attributes.status = current state)
-     */
-    onPlaybackStateDidChange(attributes: object): void {
-        this.updateNowPlayingSong(attributes)
-        // this.scrobbleSong(attributes)
-    }
-
-    /**
      * Runs on song change
      * @param attributes Music Attributes
      */


### PR DESCRIPTION
This PR fixes last.fm's plugin which broke in the recent refactor. This was due to the fact that the bespoke 'nowPlayingItemDidChangeLastFM' never got called due to it being passed a non existent plugin name of 'lastfm' rather than 'lastfm.js', however the 'onPlaybackStateDidChange' was called due to it being a general IPC call, resulting in behaviour of updating 'Now playing' but never scrobbling. 