### PR TITLE
Fix update

### DIFF
--- a/src/main/base/utils.ts
+++ b/src/main/base/utils.ts
@@ -158,6 +158,6 @@ export class utils {
 
         log.transports.file.level = "debug"
         autoUpdater.logger = log
-        await autoUpdater.checkForUpdate()
+        await autoUpdater.checkForUpdatesAndNotify()
     }
 }


### PR DESCRIPTION
```
[2022-03-01 08:24:54.075] [error] TypeError: autoUpdater.checkForUpdate is not a function
    at Function.checkForUpdate (C:\Program Files\Cider\resources\app.asar\src\main\base\utils.ts:161:27)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at IpcMainImpl.<anonymous> (C:\Program Files\Cider\resources\app.asar\src\main\base\browserwindow.ts:976:13)
[2022-03-01 08:24:54.075] [error] (node:29508) UnhandledPromiseRejectionWarning: TypeError: autoUpdater.checkForUpdate is not a function
    at Function.checkForUpdate (C:\Program Files\Cider\resources\app.asar\src\main\base\utils.ts:161:27)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at IpcMainImpl.<anonymous> (C:\Program Files\Cider\resources\app.asar\src\main\base\browserwindow.ts:976:13)
[2022-03-01 08:24:54.075] [error] (node:29508) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 4)
```