### PR TITLE
DiscordRichPresence: Fix timestamps when resuming from pause

### DIFF
--- a/src/main/plugins/discordrpc.ts
+++ b/src/main/plugins/discordrpc.ts
@@ -164,7 +164,7 @@ export default class DiscordRichPresence {
         this._activity = {
             details: attributes.name,
             state: `${attributes.artistName ? `by ${attributes.artistName}` : ''}`,
-            startTimestamp: attributes.startTime,
+            startTimestamp: Date.now() - (attributes?.durationInMillis - attributes?.remainingTime),
             endTimestamp: attributes.endTime,
             largeImageKey: attributes?.artwork?.url?.replace('{w}', '1024').replace('{h}', '1024'),
             largeImageText: attributes.albumName,


### PR DESCRIPTION
This could possibly also be fixed in cider-preload.js but might break things that expect the old `attributes.startTime` and `attributes.endTime`