### PR TITLE
Removed repeated flathub link

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@
 -->
 [![Get it from the AUR](https://img.shields.io/badge/Get_It_From_The_AUR-100000?style=for-the-badge&logo=archlinux)](https://aur.archlinux.org/packages/cider)
 
-[![Get it from Flathub](https://img.shields.io/badge/Get_It_From_Flathub-100000?style=for-the-badge&logo=flathub)](https://flathub.org/apps/details/sh.cider.Cider)
 
 ### Compiling and Configuration
 For more information surrounding configuration, compiling and other developer documentation, see the [compilation docs](https://cider.sh/compile.html).


### PR DESCRIPTION
The link to open the flathub page of the project is repeated, one of the repeated elements has been removed.