### PR TITLE
Shortcut to go to account settings when clicked on profile (box) in sidebar

### DIFF
--- a/src/renderer/views/app/sidebar.ejs
+++ b/src/renderer/views/app/sidebar.ejs
@@ -71,7 +71,7 @@
     <transition name="wpfade">
         <div class="usermenu-container" v-if="chrome.menuOpened">
             <div class="usermenu-body">
-                <button class="app-sidebar-button" style="width:100%">
+                <button class="app-sidebar-button" style="width:100%" @click="appRoute('apple-account-settings')">
 
                     <img class="sidebar-user-icon" loading="lazy"
                          :src="getMediaItemArtwork(chrome.hideUserInfo ? 'http://localhost:9000/assets/logocut.png' : (chrome.userinfo.attributes['artwork'] ? chrome.userinfo.attributes['artwork']['url'] : ''), 26)"/>


### PR DESCRIPTION
I think this shortcut is a good addition to Cider; looks neat and fitting as well. Works seamlessly both, with `Show Personal Info` turned on and off.

Thank you!