### PR TITLE
Displays album genre, even in inline album view

### DIFF
--- a/src/renderer/views/pages/cider-playlist.ejs
+++ b/src/renderer/views/pages/cider-playlist.ejs
@@ -168,6 +168,7 @@
                         </div>
                     </div>
                 </div>
+                <div class="playlist-time genre">{{this.data.relationships.tracks.data[0].attributes.genreNames[0]}}</div>
                 <div class="playlist-time">
                     {{getFormattedDate()}}
                 </div>

--- a/src/renderer/views/pages/playlist-inline.ejs
+++ b/src/renderer/views/pages/playlist-inline.ejs
@@ -179,6 +179,7 @@
                             </div>
                         </div>
                     </div>
+                    <div class="playlist-time genre">{{this.data.relationships.tracks.data[0].attributes.genreNames[0]}}</div>
                     <div class="playlist-time">
                         {{getFormattedDate()}}
                     </div>


### PR DESCRIPTION
With this PR, Cider will also display the album genre right above the album release date and other information.
This also resolves this issue https://github.com/ciderapp/Cider/issues/302.

Thank you!