### PR TITLE
Adds `Disable Private Session` button to menubar when Private Session is enabled.

### DIFF
--- a/src/renderer/views/app/sidebar.ejs
+++ b/src/renderer/views/app/sidebar.ejs
@@ -105,6 +105,11 @@
                         {{$root.getLz('app.name')}}
                     </div>
                 </button>
+                <button class="usermenu-item" v-if="cfg.general.privateEnabled"
+                        @click="cfg.general.privateEnabled = false">
+                    <span class="usermenu-item-icon"><%- include("../svg/x.svg") %></span>
+                    <span class="usermenu-item-name">{{$root.getLz('term.disable')}} {{$root.getLz('term.privateSession')}}</span>
+                </button>
                 <button class="usermenu-item" @click="appRoute('remote-pair')">
                             <span class="usermenu-item-icon"><%- include("../svg/smartphone.svg") %></span>
                             <span class="usermenu-item-name">{{$root.getLz('action.showWebRemoteQR')}}</span>


### PR DESCRIPTION
This shortcut is not only a good addition but it can also be used as an indicator to show if private session is turned on. Works flawlessly too.

Thank you!