### PR TITLE
Shows 10 `Recently Played Tracks` in Search Page inside individual Media-Square Item.

### DIFF
--- a/src/renderer/views/pages/search.ejs
+++ b/src/renderer/views/pages/search.ejs
@@ -83,6 +83,8 @@
            <div v-if="categoriesReady || getCategories()">
                 <div>
                     <div class="col" v-if="categoriesView != null && categoriesView != [] && categoriesView[0].attributes != null && categoriesView[0].attributes.title != null">
+                        <h3>{{$root.getLz('home.recentlyPlayed')}}</h3>
+                    <mediaitem-square :kind="'385'" size="600" v-for="item in recentlyPlayed.limit(10)" :item="item" :imagesize="800"></mediaitem-square>
                         <h3>{{categoriesView[0].attributes.title.stringForDisplay ?? ""}}</h3>
                     </div>  
                     <mediaitem-square :kind="'385'" size="600"
@@ -102,6 +104,7 @@
         data: function () {
             return {
                 app: this.$root,
+                recentlyPlayed: [],
                 categoriesView: [],
                 categoriesReady: false,
             }
@@ -114,8 +117,15 @@
                     return false
                 }
             },
+            async seeAllHistory() {
+                let hist = await app.mk.api.v3.music(`/v1/me/recent/played/tracks`, {
+                    l: this.$root.mklang
+                })
+                this.recentlyPlayed = hist.data.data
+            },
             async getCategories() {
                 if (this.categoriesView != [] && this.categoriesView.length > 0) { this.categoriesReady = true; return await true; } else {
+                    await this.seeAllHistory()
                     let response = await this.app.mk.api.v3.music(`/v1/recommendations/${this.app.mk.storefrontId}?timezone=${encodeURIComponent(this.app.formatTimezoneOffset())}&name=search-landing&platform=web&extend=editorialArtwork&art%5Burl%5D=f%2Cc&types=editorial-items%2Capple-curators%2Cactivities&l=${this.$root.mklang}`);
                     this.categoriesView = response.data.data;
                     console.log(this.categoriesView)


### PR DESCRIPTION
This PR adds and shows recently played tracks just like on History Page but inside the Media-Square item. The Media-Square items have been scaled down to match that of the categories present just down below.

This would be a great addition to Cider as it is a great shortcut to play previously searched and played tracks. This has been tested and works, Mergeable.

Thank you!