### PR TITLE
Cider PKGBUILD Test

### DIFF
--- a/cider.lock
+++ b/cider.lock
@@ -3096,9 +3096,9 @@ dns-equal@^1.0.0:
   resolved "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz"
   integrity sha1-s55/HabrCnW6nBcySzR1PEfgZU0=
 
-"dns-js@github:bitfocus/node-dns-js#v0.2.2":
-  version "0.2.2"
-  resolved "git+ssh://git@github.com/bitfocus/node-dns-js.git#e5f0c3da63653398005bf36f66ad0b77770dcad6"
+"dns-js@git+https://github.com/ciderapp/node-dns-js.git":
+    version "0.2.1"
+  resolved "git+https://github.com/ciderapp/node-dns-js.git#212b6c903db40bcd501af741e51cd20d676acbc9"
   dependencies:
     debug "^2.1.0"
     qap "^3.1.2"


### PR DESCRIPTION
Don't know why cider needs in pkgbuild a file.lock autogenerated, but wherever this fixed fetch packages in arch PGKBUILD compilation 

Building Cider on v1.4.3.3111.084d9157 : [Install Build Dependencies] | Build | Done
yarn install v1.22.18
[1/4] Resolving packages...
[2/4] Fetching packages...
error Command failed.
Exit code: 128
Command: git
Arguments: ls-remote --tags --heads ssh://git@github.com/bitfocus/node-dns-js.git
Directory: /home/matt/.cache/yay/cider-git/src/Cider
Output:
Host key verification failed.
fatal: Could not read from remote repository.
Please make sure you have the correct access rights
and the repository exists.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.


PS: Gambare Gambare Cider Team, Love this project. 