### PR TITLE
Album view: hide tab controls when only one tab exists

### DIFF
--- a/src/renderer/views/pages/cider-playlist.ejs
+++ b/src/renderer/views/pages/cider-playlist.ejs
@@ -146,7 +146,7 @@
             </div>
             <div class="playlist-body scrollbody">
 
-                <b-tabs pills class="track-pills pilldim" align="center" content-class="mt-3">
+                <b-tabs pills class="track-pills pilldim" align="center" content-class="mt-3" :nav-class="navClass(data)">
                     <b-tab :title="$root.getLz('term.tracks')">
                         <div @wheel="minClass(true)" @scroll="minClass(true)">
                         <div class="">
@@ -713,6 +713,10 @@
                 })
 
 
+            },
+            navClass(data) {
+                if (data && typeof data.views != "undefined") return "";
+                return "d-none";
             }
 
         }

--- a/src/renderer/views/pages/cider-playlist.ejs
+++ b/src/renderer/views/pages/cider-playlist.ejs
@@ -146,7 +146,7 @@
             </div>
             <div class="playlist-body scrollbody">
 
-                <b-tabs pills class="track-pills pilldim" align="center" content-class="mt-3" :nav-class="navClass(data)">
+                <b-tabs pills class="track-pills pilldim" align="center" content-class="mt-3" :nav-wrapper-class="navClass(data)">
                     <b-tab :title="$root.getLz('term.tracks')">
                         <div @wheel="minClass(true)" @scroll="minClass(true)">
                         <div class="">


### PR DESCRIPTION
A small update to the new album view that hides the tab controls when they are not necessary (only one tab exists).