### PR TITLE
prefer musixmatch instead of qq

### DIFF
--- a/src/renderer/main/vueapp.js
+++ b/src/renderer/main/vueapp.js
@@ -2810,7 +2810,7 @@ const app = new Vue({
                                             });
                                         app.lyrics = preLrc;
                                     }
-                                    if (lrcfile != null && lrcfile != '' && lang != "disabled") {
+                                    if (lrcfile != null && lrcfile != '') {
                                         // load translation
                                         getMXMTrans(id, lang, token);
                                     } else {


### PR DESCRIPTION
This fixes a bug so that Cider still prefers Musixmatch lyrics instead of QQ when there isn't any translation available.
(You will get the original lyrics if lang=disabled)

The lang check is not really needed there, because it will be checked again in the method getMXMTrans.

also prevents this issue a bit: https://github.com/ciderapp/Cider/issues/923