### PR TITLE
Limits the display of very large queue items to 50 at a time

### DIFF
--- a/src/renderer/views/components/queue.ejs
+++ b/src/renderer/views/components/queue.ejs
@@ -13,12 +13,11 @@
         </div>
         <div class="queue-body" v-if="page == 'queue'">
             <draggable v-model="queueItems" @start="drag=true" @end="drag=false;move()">
-                <template v-for="(queueItem, position) in queueItems">
-                    <div v-if="position <= queuePosition" style="display: none;">{{ position }}</div>
+                <template v-for="(queueItem, position) in displayQueueItems">
                     <div class="cd-queue-item"
                          :class="{selected: selectedItems.includes(position)}"
                          @click="select($event, position)"
-                         @dblclick="playQueueItem(position)" v-else :key="position"
+                         @dblclick="playQueueItem(position)" :key="position"
                          @contextmenu="selected = position;queueContext($event, queueItem.item, position)">
                         <div class="row">
                             <div class="col-auto flex-center">
@@ -59,6 +58,13 @@
                 history: [],
                 page: "queue",
                 app: this.$root
+            }
+        },
+        computed: {
+            displayQueueItems() {
+                const displayLimit = 50;
+                const lastDisplayPosition = Math.min(displayLimit + this.queuePosition, this.queueItems.length);
+                return this.queueItems.slice(this.queuePosition, lastDisplayPosition);
             }
         },
         mounted() {


### PR DESCRIPTION
With very large queues (shuffling all songs in a large library, for example) the queue UI can lag quite a bit. This PR limits the displayed queue to a sensible 50 items. If 50 is too small, too large, it shouldn't be much work to make this a configurable setting. The displayed queue is recomputed when the queue changes- it should always display the next 50 items or the end of the queue.