### PR TITLE
Fix now playing context menu not rendering from 'songs' page

### DIFF
--- a/src/renderer/main/vueapp.js
+++ b/src/renderer/main/vueapp.js
@@ -4009,7 +4009,8 @@ const app = new Vue({
                 }
             }
 
-            if (app.mk.nowPlayingItem._container["attributes"] && app.mk.nowPlayingItem._container.name != "station") {
+            const nowPlayingContainer = app.mk.nowPlayingItem._container;
+            if (nowPlayingContainer && nowPlayingContainer["attributes"] && nowPlayingContainer.name != "station") {
                 menus.normal.items.find(x => x.id == "showInMusic").hidden = false
             }
 


### PR DESCRIPTION
There are times where nowPlaying._context is undefined, so I added a check around it's presence for enabling the 'showInMusic' menu item.

One way to replicate the issue:

- Navigate to the songs page
- Shuffle songs
- Right click the now playing bar OR click the bar's ellipsis in attempt to open a context menu
