### PR TITLE
macOS: fix back button padding

### DIFF
--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -12944,6 +12944,7 @@ body[platform='darwin'] #window-controls-container {
 }
 body[platform='darwin'] .app-chrome .app-chrome-item > .app-mainmenu {
   opacity: 0;
+  width: 52px;
   pointer-events: none;
   -webkit-app-region: drag;
 }

--- a/src/renderer/style.less
+++ b/src/renderer/style.less
@@ -3289,6 +3289,7 @@ body[platform='darwin'] {
 
   .app-chrome .app-chrome-item > .app-mainmenu {
     opacity: 0;
+    width: 52px;
     pointer-events: none;
     -webkit-app-region: drag;
   }


### PR DESCRIPTION
Fixes #879

Before:
<img width="216" alt="before" src="https://user-images.githubusercontent.com/44944781/166590814-b6ebb49e-698e-4467-811b-4ed8bb610e00.png">

After:
![after](https://user-images.githubusercontent.com/44944781/166590822-a1947348-43fd-4fdc-8a04-35ecd7388486.png)
