### PR TITLE
Add mpris slot for snap package

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,6 +178,15 @@
       "isRelocatable": false,
       "overwriteAction": "upgrade"
     },
+    "snap": {
+      "slots": [
+        {
+          "mpris": {
+            "interface": "mpris"
+          }
+        }
+      ]
+    },
     "dmg": {
       "background": "./resources/bg.png",
       "icon": "resources/icons/icon.ico"


### PR DESCRIPTION
#575 reported that the media keys in the snap release are broken, however apparently the user used a work-around to fix it. Does not change the fact it's still broken in the current release on the Snap Store.

This PR fixes the media keys for the snap package for good by adding the mpris slot for the snap package.