### PR TITLE
Search-hints-container top and padding margin

### DIFF
--- a/src/renderer/less/elements.less
+++ b/src/renderer/less/elements.less
@@ -2091,6 +2091,12 @@ input[type=checkbox][switch]:checked:active::before {
   }
 }
 
+.app-sidebar-header 
+.search-input-container .search-hints-container {
+  top: 38px;
+  padding: 3px;
+}
+
 .content-inner {
   &.library-page {
     .heart-icon {


### PR DESCRIPTION
A very short commit that aims to fix the huge margin to the search hints on top and improved left and right margin.

Before:
![image](https://user-images.githubusercontent.com/59381835/170595226-1e7b1282-28ff-4e89-8e3a-e17b392eb1aa.png)

After:
![image](https://user-images.githubusercontent.com/59381835/170595184-2a1cfd54-7bc6-4057-97c4-e64da2b76476.png)
