### PR TITLE
Fix for Listen Now tab inflict with artist mediaitem-card

### DIFF
--- a/src/renderer/less/elements.less
+++ b/src/renderer/less/elements.less
@@ -1089,11 +1089,12 @@
   &.mediaitem-card {
     background: #ccc;
     background: var(--spcolor);
-    height: 272px;
+    height: 298px;
     width: 230px;
     overflow: hidden;
     position: relative;
-    border-radius: calc(var(--mediaItemRadius) * 2);
+    border-radius: calc(var(--mediaItemRadius) * 3);
+    box-shadow: var(--mediaItemShadow);
 
     .artwork {
       width: 230px;
@@ -2090,6 +2091,17 @@ input[type=checkbox][switch]:checked:active::before {
     }
   }
 }
+
+.latestRelease {
+  .subtitle {
+    padding-top: 6px;
+  }
+  .mediaitem-card {
+    height: 272px;
+    box-shadow: unset;  
+  }
+}
+
 
 .content-inner {
   &.library-page {


### PR DESCRIPTION
This is a quick fix for the listen now page mediaitem-card being affected due to the recent commit:
https://github.com/ciderapp/Cider/pull/1079

The artist page now has its own class and doesn't share it with other pages/tabs.

also as a bonus, x3 instead of x2 rounded borders in the listen now page and the borders are also back for them. 


**a preview:**
![image](https://user-images.githubusercontent.com/59381835/170628003-a19e6924-a4e1-428c-895e-75e6a2fc29d1.png)
