### PR TITLE
Added basic/advanced volume control tooltip

### DIFF
--- a/src/i18n/en_US.json
+++ b/src/i18n/en_US.json
@@ -367,6 +367,7 @@
   "settings.header.audio": "Audio",
   "settings.header.audio.description": "Adjust the audio settings for Cider.",
   "settings.option.audio.volumeStep": "Volume Step",
+  "settings.option.audio.advanced": "Advanced Volume Control",
   "settings.option.audio.maxVolume": "Max Volume",
   "settings.option.audio.changePlaybackRate": "Change Playback Rate",
   "settings.option.audio.playbackRate": "Playback Rate",

--- a/src/renderer/main/vueapp.js
+++ b/src/renderer/main/vueapp.js
@@ -297,7 +297,8 @@ const app = new Vue({
             }
         },
         formatVolumeTooltip() {
-            return this.cfg.audio.dBSPL ? (Number(this.cfg.audio.dBSPLcalibration) + (Math.log10(this.mk.volume) * 20)).toFixed(2) + ' dB SPL' : (Math.log10(this.mk.volume) * 20).toFixed(2) + ' dBFS'
+            let advancedTooltip = this.cfg.audio.dBSPL ? (Number(this.cfg.audio.dBSPLcalibration) + (Math.log10(this.mk.volume) * 20)).toFixed(2) + ' dB SPL' : (Math.log10(this.mk.volume) * 20).toFixed(2) + ' dBFS'
+			return this.cfg.audio.advanced ? advancedTooltip : (this.mk.volume * 100).toFixed(0) + '%'
         },
         mainMenuVisibility(val) {
             if(this.chrome.sidebarCollapsed) {

--- a/src/renderer/views/components/audio-controls.ejs
+++ b/src/renderer/views/components/audio-controls.ejs
@@ -35,6 +35,16 @@
                                v-model="maxVolume"/>
                     </div>
                 </div>
+				<div class="md-option-line">
+					<div class="md-option-segment">
+						{{$root.getLz('settings.option.audio.advanced')}}
+					</div>
+					<div class="md-option-segment md-option-segment_auto">
+						<label>
+							<input type="checkbox" v-model="app.cfg.audio.advanced" switch/>
+						</label>
+					</div>
+				</div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
As a new user of Cider, I was very confused by what dBFS meant in the volume control so I decided to change it to something a lot more user friendly whilst still giving users the option to switch back to the previous volume control tooltip. I've added the basic functionality of being able to switch between the two styles of tooltips.

This was made with new users in mind, so anyone who installs Cider for the first time will see a percentage volume control which is probably something they're more familiar with rather than in dBFS.

With advanced volume control switched off
![image](https://user-images.githubusercontent.com/15069574/171071822-7947cacd-efac-4931-8582-3697327d2e17.png)

Where you can find the toggle switch
![image](https://user-images.githubusercontent.com/15069574/171071864-b45c1860-8fd4-49fa-9a42-85deaee9ab2a.png)
