### PR TITLE
Update to use setZoomFactor method to handle UI scaling

### DIFF
--- a/src/renderer/main/vueapp.js
+++ b/src/renderer/main/vueapp.js
@@ -498,11 +498,9 @@ const app = new Vue({
             history.forward()
         },
         getHTMLStyle() {
-            if (app.cfg.visual.uiScale != 1) {
-                document.querySelector("body").style.zoom = app.cfg.visual.uiScale
-            } else {
-                document.querySelector("body").style.zoom = ""
-            }
+			
+			ipcRenderer.send("setScreenScale", app.cfg.visual.uiScale);
+            
         },
         resetState() {
             this.menuPanel.visible = false;

--- a/src/renderer/main/vueapp.js
+++ b/src/renderer/main/vueapp.js
@@ -499,9 +499,9 @@ const app = new Vue({
         },
         getHTMLStyle() {
             if (app.cfg.visual.uiScale != 1) {
-                document.querySelector("#app").style.zoom = app.cfg.visual.uiScale
+                document.querySelector("body").style.zoom = app.cfg.visual.uiScale
             } else {
-                document.querySelector("#app").style.zoom = ""
+                document.querySelector("body").style.zoom = ""
             }
         },
         resetState() {


### PR DESCRIPTION
Changed the code to use Electron's built in setZoomFactor to handle UI scaling. This fixes the tooltips not being positioned correctly when hoving over elements when UI is scaled. Media and Volume controls will now correctly reposition itself at the bottom when the UI is scaled and elements at the top start overflowing.

![image](https://user-images.githubusercontent.com/15069574/171518512-25535214-36b1-4ff1-bee0-998d4f902d67.png)

This also fixes issue #862 