### PR TITLE
Adjust height for media card so subtitle fits in card

### DIFF
--- a/src/renderer/less/elements.less
+++ b/src/renderer/less/elements.less
@@ -1136,7 +1136,7 @@
   &.mediaitem-card {
     background   : #ccc;
     background   : var(--spcolor);
-    height       : 298px;
+    height       : 302px;
     width        : 230px;
     overflow     : hidden;
     position     : relative;
@@ -1205,7 +1205,7 @@
       -webkit-box-orient: vertical;
       -webkit-line-clamp: 3;
       overflow          : hidden;
-      max-height        : 3.8em;
+      max-height        : 4.8em;
       z-index           : 1;
     }
 


### PR DESCRIPTION
Adjusted the height of the media cards in "Listen Now" so that the subtitle no longer clips at the bottom

Before:
![image](https://user-images.githubusercontent.com/15069574/172058386-7c7a51b8-6be2-43da-9223-1c2e8bc52c0e.png)

After: 
![image](https://user-images.githubusercontent.com/15069574/172058428-0fa79247-1aed-4423-8d34-e33400cdc7a2.png)

This will also fix issue #1126 