### PR TITLE
Fix playback issues where user has AudioContext disabled

### DIFF
--- a/src/renderer/audio/audio.js
+++ b/src/renderer/audio/audio.js
@@ -906,7 +906,7 @@ const CiderAudio = {
         try { for (var i of CiderAudio.audioNodes.audioBands) { i.disconnect(); } CiderAudio.audioNodes.vibrantbassNode = null} catch (e) { };
         console.debug("[Cider][Audio] Finished hierarchical unloading")
     },
-    hierarchical_loading: function () {
+    hierarchical_loading: async function () {
         const configMap = new Map([
             ['spatial', app.cfg.audio.maikiwiAudio.spatial === true],
             ['n5', app.cfg.audio.maikiwiAudio.atmosphereRealizer2 === true],   


### PR DESCRIPTION
By having this function as synchronous, it will present an error whenever someone with AudioContext disabled tries to play a track and Cider will give up on playing said track.

Checked the code before the Phase 1 update, and this function was asynchronous, therefore reverting it back to async. Tracks now play even with AudioContext disabled.

This might potentially fix issue #1128 