### PR TITLE
Plz

### DIFF
--- a/src/main/base/store.ts
+++ b/src/main/base/store.ts
@@ -84,21 +84,22 @@ export class Store {
                 ],
                 "webRemote": [
                     "CommandOrControl",
+                    process.platform == "darwin" ? "Option" : (process.platform == "linux" ? "Shift" : "Alt"),
                     "W"
                 ],
                 "audioSettings": [
                     "CommandOrControl",
-                    process.platform == "darwin" ? "Option" : "Alt",
+                    process.platform == "darwin" ? "Option" : (process.platform == "linux" ? "Shift": "Alt"),
                     "A"
                 ],
                 "pluginMenu": [
                     "CommandOrControl",
-                    process.platform == "darwin" ? "Option" : "Alt",
+                    process.platform == "darwin" ? "Option" : (process.platform == "linux" ? "Shift": "Alt"),
                     "P"
                 ],
                 "castToDevices": [
                     "CommandOrControl",
-                    process.platform == "darwin" ? "Option" : "Alt",
+                    process.platform == "darwin" ? "Option" : (process.platform == "linux" ? "Shift": "Alt"),
                     "C"
                 ],
                 "settings": [

--- a/src/renderer/views/pages/keybinds.ejs
+++ b/src/renderer/views/pages/keybinds.ejs
@@ -233,10 +233,10 @@
                 app.cfg.general.keybindings.albums = [app.platform == "darwin" ? "Command" : "Control", "A"];
                 app.cfg.general.keybindings.artists = [app.platform == "darwin" ? "Command" : "Control", "D"];
                 app.cfg.general.keybindings.togglePrivateSession = [app.platform == "darwin" ? "Command" : "Control", "P"];
-                app.cfg.general.keybindings.webRemote = [app.platform == "darwin" ? "Command" : "Control", "W"];
-                app.cfg.general.keybindings.audioSettings = [app.platform == "darwin" ? "Option" : "Alt", "A"];
-                app.cfg.general.keybindings.pluginMenu = [app.platform == "darwin" ? "Option" : "Alt", "P"];
-                app.cfg.general.keybindings.castToDevices = [app.platform == "darwin" ? "Option" : "Alt", "C"];
+                app.cfg.general.keybindings.webRemote = [app.platform == "darwin" ? "Command" : "Control",app.platform == "darwin" ? "Option" : (app.platform == "linux" ? "Shift" : "Alt"), "W"];
+                app.cfg.general.keybindings.audioSettings = [app.platform == "darwin" ? "Command" : "Control",app.platform == "darwin" ? "Option" : (app.platform == "linux" ? "Shift" : "Alt"), "A"];
+                app.cfg.general.keybindings.pluginMenu = [app.platform == "darwin" ? "Command" : "Control",app.platform == "darwin" ? "Option" : (app.platform == "linux" ? "Shift" : "Alt"), "P"];
+                app.cfg.general.keybindings.castToDevices = [app.platform == "darwin" ? "Command" : "Control",app.platform == "darwin" ? "Option" : (app.platform == "linux" ? "Shift" : "Alt"), "C"];
                 app.cfg.general.keybindings.settings = [app.platform == "darwin" ? "Command" : "Control", ","];
                 app.cfg.general.keybindings.openDeveloperTools = [app.platform == "darwin" ? "Command" : "Control", app.platform == "darwin" ? "Option" : "Shift", "I"];
                 notyf.success(app.getLz('settings.notyf.general.keybindings.update.success'));


### PR DESCRIPTION
In some Linux Distro/DE the "CTRL+ALT+*" changes global configs in some shitties and werever.

I propose some fix for this combined keys:

"Command+Option" to mac
"CTRL+Alt" to windows
"CTRL+Shift" to linux

I know I can change, but this is more simple and compatible. 