### PR TITLE
Disable lyrics scrolling while the user is doing it themself

### DIFF
--- a/src/web-remote/index.js
+++ b/src/web-remote/index.js
@@ -21,6 +21,7 @@ var app = new Vue({
                 start: 0,
                 end: 0
             },
+            lyricsScrollingBlocked: false,
             queue: {},
             lowerPanelState: "controls",
             userInteraction: false
@@ -318,12 +319,18 @@ var app = new Vue({
                 return {}
             }
         },
+        blockLyricsScrolling() {
+            this.lyricsScrollingBlocked = true;
+            setTimeout(() => {
+                this.lyricsScrollingBlocked = false;
+            }, 100);
+        },
         getLyricClass(start, end) {
             var currentTime = this.getCurrentTime();
             // check if currenttime is between start and end
             if (currentTime >= start && currentTime <= end) {
                 setTimeout(() => {
-                    if (document.querySelector(".lyric-line.active")) {
+                    if (document.querySelector(".lyric-line.active") && !this.lyricsScrollingBlocked) {
                         document.querySelector(".lyric-line.active").scrollIntoView({
                             behavior: "smooth",
                             block: "center"

--- a/src/web-remote/views/index.ejs
+++ b/src/web-remote/views/index.ejs
@@ -723,7 +723,7 @@
                             </div>
                         </div>
                     </div>
-                    <div class="md-body lyric-body">
+                    <div class="md-body lyric-body" @scroll.passive="blockLyricsScrolling()">
                         <template v-if="player.lyrics">
                             <template v-for="lyric in player.lyrics" v-if="lyric.line != 'lrcInstrumental'">
                                 <h3 class="lyric-line" @click="seekTo(lyric.startTime, false)"

--- a/src/web-remote/views/index.ejs
+++ b/src/web-remote/views/index.ejs
@@ -91,7 +91,7 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="md-body lyric-body" style="width:100%;">
+                        <div class="md-body lyric-body" style="width:100%;" @scroll.passive="blockLyricsScrolling()">
                             <template v-if="player.lyrics">
                                 <template v-for="lyric in player.lyrics" v-if="lyric.line != 'lrcInstrumental'">
                                     <h3 class="lyric-line" @click="seekTo(lyric.startTime, false)"


### PR DESCRIPTION
Currently the active lyric element is constantly being scrolled into view even when the user is trying to do it themself, I changed this behavior, temporarily disabling scrolling active lyric into view while the user is scrolling