### PR TITLE
GitHub Themes/Plugins list limit 30 -> 100

### DIFF
--- a/src/renderer/views/pages/plugins-github.ejs
+++ b/src/renderer/views/pages/plugins-github.ejs
@@ -176,7 +176,7 @@
                     redirect: 'follow'
                 };
 
-                fetch("https://api.github.com/search/repositories?q=topic:cidermusicplugin fork:true", requestOptions)
+                fetch("https://api.github.com/search/repositories?q=topic:cidermusicplugin fork:true&per_page=100", requestOptions)
                     .then(response => response.text())
                     .then(result => {
                         self.repos = JSON.parse(result).items

--- a/src/renderer/views/pages/themes-github.ejs
+++ b/src/renderer/views/pages/themes-github.ejs
@@ -184,7 +184,7 @@
                     redirect: 'follow'
                 };
 
-                fetch("https://api.github.com/search/repositories?q=topic:cidermusictheme fork:true", requestOptions)
+                fetch("https://api.github.com/search/repositories?q=topic:cidermusictheme fork:true&per_page=100", requestOptions)
                     .then(response => response.text())
                     .then(result => {
                         let items = JSON.parse(result).items


### PR DESCRIPTION
Currently some themes are missing from the GitHub themes page due to the GitHub API's default per_page parameter being 30, and there currently being 38 themes out in the world. This change increases that limit to 100 which should be good for a long while. In the future, if there are ever more than 100 themes (lmao), may have to make use of the API's pages feature to be able to list them all.