### PR TITLE
Remove automatic opening of the sidebar on quick nav click

### DIFF
--- a/src/renderer/main/vueapp.js
+++ b/src/renderer/main/vueapp.js
@@ -325,11 +325,7 @@ const app = new Vue({
             let advancedTooltip = this.cfg.audio.dBSPL ? (Number(this.cfg.audio.dBSPLcalibration) + (Math.log10(this.mk.volume) * 20)).toFixed(2) + ' dB SPL' : (Math.log10(this.mk.volume) * 20).toFixed(2) + ' dBFS'
             return this.cfg.audio.advanced ? advancedTooltip : (this.mk.volume * 100).toFixed(0) + '%'
         },
-        mainMenuVisibility(val, isContextMenu) {
-            if (this.chrome.sidebarCollapsed && !isContextMenu) {
-                this.chrome.sidebarCollapsed = false
-                return
-            }
+        mainMenuVisibility(val) {
             if (val) {
                 (this.mk.isAuthorized) ? this.chrome.menuOpened = !this.chrome.menuOpened : false;
                 if (!this.mk.isAuthorized) {

--- a/src/renderer/views/app/chrome-top.ejs
+++ b/src/renderer/views/app/chrome-top.ejs
@@ -9,8 +9,8 @@
       </div>
     </div>
     <div class="app-chrome-item full-height" v-else>
-      <button class="app-mainmenu" @blur="mainMenuVisibility(false, true)" @click="mainMenuVisibility(true, false)"
-        @contextmenu="mainMenuVisibility(true, true)" :class="{active: chrome.menuOpened}"
+      <button class="app-mainmenu" @blur="mainMenuVisibility(false)" @click="mainMenuVisibility(true)"
+        @contextmenu="mainMenuVisibility(true)" :class="{active: chrome.menuOpened}"
         :aria-label="$root.getLz('term.quickNav')"></button>
     </div>
     <template v-if="getThemeDirective('appNavigation') != 'seperate'">
@@ -269,8 +269,8 @@
       </div>
     </div>
     <div class="app-chrome-item full-height" v-else-if="platform != 'darwin' && !chrome.nativeControls">
-      <button class="app-mainmenu" @blur="mainMenuVisibility(false, true)" @click="mainMenuVisibility(true, false)"
-        @contextmenu="mainMenuVisibility(true, true)" :class="{active: chrome.menuOpened}"></button>
+      <button class="app-mainmenu" @blur="mainMenuVisibility(false)" @click="mainMenuVisibility(true)"
+        @contextmenu="mainMenuVisibility(true)" :class="{active: chrome.menuOpened}"></button>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Following the latest changes to the collapsible sidebar, this PR removes the automatic opening of the sidebar when the quick nav button is clicked.