### PR TITLE
fixed podcast title padding in podcast details

### DIFF
--- a/src/renderer/less/pages.less
+++ b/src/renderer/less/pages.less
@@ -288,6 +288,7 @@
 
     .podcast-header {
       text-align: center;
+      padding: 0 1rem;
     }
 
     .podcast-play-btn {


### PR DESCRIPTION
fixed podcast title padding in podcast details

before:
![original](https://user-images.githubusercontent.com/68981163/174334277-414cf61e-ac96-4701-91d9-70998b2e559a.png)

after:
![with padding 0 1rem](https://user-images.githubusercontent.com/68981163/174334294-a2f70a35-3804-48dd-9393-052ab2c1c22e.png)

