### PR TITLE
album banners (aka editorial artwork) (aka album hero)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -328,3 +328,4 @@ savedconfig/cider-config.json
 savedconfig/config.json
 savedconfig/session.json
 savedconfig/window-state.json
+src/main/base/sample.json

--- a/src/renderer/less/pages.less
+++ b/src/renderer/less/pages.less
@@ -672,6 +672,13 @@
           -webkit-mask-image: -webkit-radial-gradient(center, circle cover, rgba(0, 0, 0, 1) 50%, rgba(0, 0, 0, 0) 75%);
           border-radius     : 0px;
         }
+        .hero-tint {
+          position: absolute; 
+          top : 0;
+          opacity: 0.6;
+          width: 100%; 
+          height: 100%;
+        }
       }
 
       >.row {

--- a/src/renderer/less/pages.less
+++ b/src/renderer/less/pages.less
@@ -658,6 +658,22 @@
       width          : 100%;
       height         : 100%;
 
+      .playlist-hero {
+        width             : 100%;
+        transform: translateX(+25%);
+        position: absolute;
+        z-index : -1;
+        top     : 0;
+        left    : 0;
+        right   : 0;
+        bottom  : 0;
+    
+        .mediaitem-artwork {
+          -webkit-mask-image: -webkit-radial-gradient(center, circle cover, rgba(0,0,0,1) 50%, rgba(0,0,0,0) 75%);
+          border-radius: 0px;
+        }
+      }
+
       >.row {
         width: calc(100% - 32px);
       }

--- a/src/renderer/less/pages.less
+++ b/src/renderer/less/pages.less
@@ -700,6 +700,10 @@
           flex-shrink    : unset;
         }
 
+        .search-input::placeholder {
+          color: var(--heroplaceholdercolor)
+        }
+
         .nameEdit {
           font-weight: 700;
           font-size  : 1.6rem;

--- a/src/renderer/less/pages.less
+++ b/src/renderer/less/pages.less
@@ -659,18 +659,18 @@
       height         : 100%;
 
       .playlist-hero {
-        width             : 100%;
-        transform: translateX(+25%);
-        position: absolute;
-        z-index : -1;
-        top     : 0;
-        left    : 0;
-        right   : 0;
-        bottom  : 0;
+        width     : 100%;
+        transform : translateX(+25%);
+        position  : absolute;
+        z-index   : -1;
+        top       : 0;
+        left      : 0;
+        right     : 0;
+        bottom    : 0;
     
         .mediaitem-artwork {
-          -webkit-mask-image: -webkit-radial-gradient(center, circle cover, rgba(0,0,0,1) 50%, rgba(0,0,0,0) 75%);
-          border-radius: 0px;
+          -webkit-mask-image: -webkit-radial-gradient(center, circle cover, rgba(0, 0, 0, 1) 50%, rgba(0, 0, 0, 0) 75%);
+          border-radius     : 0px;
         }
       }
 

--- a/src/renderer/views/pages/artist.ejs
+++ b/src/renderer/views/pages/artist.ejs
@@ -25,7 +25,8 @@
                     </div>
                     <div class="col flex-center artist-title"
                          :class="{'artist-animation-on': (data.attributes.editorialVideo && (data.attributes.editorialVideo.motionArtistWide16x9 || data.attributes.editorialVideo.motionArtistFullscreen16x9)) || hasHero() }"
-                    >
+                         :style="{ 'color': '#' +hasHeroObject()?.textColor1 ?? ''}"
+                         >
                         <button class="artist-play" @click="app.mk.setStationQueue({artist:'a-'+data.id}).then(()=>{
                         app.mk.play()
                     })" :aria-label="app.getLz('term.play')"><%- include("../svg/play.svg") %></button>
@@ -182,6 +183,16 @@
                     return this.data.attributes?.editorialArtwork?.subscriptionHero.url
                 }
                 return false;
+            },
+            hasHeroObject() {
+                if(this.data.attributes?.editorialArtwork?.centeredFullscreenBackground){
+                    return this.data.attributes?.editorialArtwork?.centeredFullscreenBackground
+                } else if(this.data.attributes?.editorialArtwork?.bannerUber) {
+                    return this.data.attributes?.editorialArtwork?.bannerUber
+                } else if(this.data.attributes?.editorialArtwork?.subscriptionHero){
+                    return this.data.attributes?.editorialArtwork?.subscriptionHero
+                }
+                return [];
             },
             isHeaderVisible(visible) {
                 this.headerVisible = visible

--- a/src/renderer/views/pages/artist.ejs
+++ b/src/renderer/views/pages/artist.ejs
@@ -178,7 +178,7 @@
                     return this.data.attributes?.editorialArtwork?.centeredFullscreenBackground.url
                 } else if(this.data.attributes?.editorialArtwork?.bannerUber) {
                     return this.data.attributes?.editorialArtwork?.bannerUber.url
-                }else if(this.data.attributes?.editorialArtwork?.subscriptionHero){
+                } else if(this.data.attributes?.editorialArtwork?.subscriptionHero){
                     return this.data.attributes?.editorialArtwork?.subscriptionHero.url
                 }
                 return false;

--- a/src/renderer/views/pages/cider-playlist.ejs
+++ b/src/renderer/views/pages/cider-playlist.ejs
@@ -8,11 +8,15 @@
             </div>
         </template>
         <template v-if="app.playlists.loadingState == 1">
-            <div class="playlist-display"
+            <div class="playlist-display" :style="{ 'background-color': '#' +hasHeroObject()?.bgColor ?? '' }"
                  @mouseover.self="minClass(false)">
                 <div class="playlistInfo">
                     <div class="playlist-hero" v-if="hasHero()">
                         <mediaitem-artwork shadow="none" :url="hasHero()" size="2160" />
+                        <div class="hero-tint" :style="{ 'position':'absolute', 'top' : '0',
+                        'background-color': '#' + hasHeroObject()?.bgColor ?? '' , // 50%
+                        'opacity': '0.6',
+                        'width':'100%', 'height':'100%'}"></div> 
                     </div>
                     <div class="row">
                         <div class="col-auto flex-center" @mouseover="minClass(false)">
@@ -29,7 +33,7 @@
                         <div class="col playlist-info">
                             <template v-if="!editorialNotesExpanded">
                                 <div>
-                                    <div class="playlist-name" @mouseover="minClass(false)" @click="editPlaylistName()" v-show="!nameEditing">
+                                    <div class="playlist-name" @mouseover="minClass(false)" @click="editPlaylistName()" v-show="!nameEditing" :style="{ 'color': '#' +hasHeroObject()?.textColor1 ?? '', 'filter' : 'drop-shadow(1px 3px 8px #' + hasHeroObject()?.textColor4 ?? '' +')' }">
                                         {{data.attributes ? (data.attributes.name ??
                                         (data.attributes.title ?? '') ?? '') : ''}}
                                     </div>
@@ -41,17 +45,18 @@
                                                                                            @change="editPlaylist"
                                                                                            @keydown.enter="editPlaylist"/>
                                     </div>
-                                    <div class="playlist-time genre" style="margin: 0px;">{{getAlbumGenre()}}</div>
+                                    <div class="playlist-time genre" style="margin: 0px;" :style="{ 'color': '#' + hasHeroObject()?.textColor2 ?? '' }">{{getAlbumGenre()}}</div>
                                     <div class="playlist-artist item-navigate"
                                          v-if="getArtistName(data) != '' && !useArtistChip"
                                          @click="data.attributes && data.attributes.artistName ? app.searchAndNavigate(data,'artist') : ''">
                                         {{getArtistName(data)}}
                                     </div>
                                     <template v-if="useArtistChip">
-                                        <artist-chip v-for="artist in data.relationships.artists?.data"
+                                        <artist-chip v-for="artist in data.relationships.artists?.data"  :style="{ 'color': '#' +hasHeroObject()?.textColor3 ?? '' }"
                                                      :item="artist"></artist-chip>
                                     </template>
                                     <div class="playlist-desc"
+                                        :style="{ 'color': '#' +hasHeroObject()?.textColor3 ?? '' }"
                                          v-if="(data.attributes.description && (data.attributes.description.standard || data.attributes.description.short)) || (data.attributes.editorialNotes && (data.attributes.editorialNotes.standard || data.attributes.editorialNotes.short))">
                                         <div v-if="(data.attributes.description?.short ?? data.attributes.editorialNotes?.short) != null"
                                              class="content"
@@ -123,7 +128,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="artworkContainer" v-if="data.attributes.artwork != null">
+                <div class="artworkContainer" v-if="data.attributes.artwork != null && !hasHero()">
                     <artwork-material :url="data.attributes.artwork.url" size="500" images="1"></artwork-material>
                 </div>
                 <button class="md-btn md-btn-small editTracksBtn" v-if="(data.attributes.canEdit && data.type == 'library-playlists')" @click="editing = !editing">
@@ -376,6 +381,16 @@
                     return this.data.attributes?.editorialArtwork?.storeFlowcase.url
                 }
                 return false;
+            },
+            hasHeroObject() {
+                if(this.data.attributes?.editorialArtwork?.bannerUber){
+                    return this.data.attributes?.editorialArtwork?.bannerUber
+                } else if(this.data.attributes?.editorialArtwork?.subscriptionHero) {
+                    return this.data.attributes?.editorialArtwork?.subscriptionHero
+                } else if(this.data.attributes?.editorialArtwork?.storeFlowcase){
+                    return this.data.attributes?.editorialArtwork?.storeFlowcase
+                }
+                return [];
             },
             getBadges() {
                 return

--- a/src/renderer/views/pages/cider-playlist.ejs
+++ b/src/renderer/views/pages/cider-playlist.ejs
@@ -11,6 +11,9 @@
             <div class="playlist-display"
                  @mouseover.self="minClass(false)">
                 <div class="playlistInfo">
+                    <div class="playlist-hero" v-if="hasHero()">
+                        <mediaitem-artwork shadow="none" :url="hasHero()" size="2048" />
+                    </div>
                     <div class="row">
                         <div class="col-auto flex-center" @mouseover="minClass(false)">
                             <div class="mediaContainer">
@@ -363,6 +366,16 @@
             },
             isHeaderVisible(visible) {
                 this.headerVisible = visible
+            },
+            hasHero() {
+                if(this.data.attributes?.editorialArtwork?.bannerUber){
+                    return this.data.attributes?.editorialArtwork?.bannerUber.url
+                } else if(this.data.attributes?.editorialArtwork?.subscriptionHero) {
+                    return this.data.attributes?.editorialArtwork?.subscriptionHero.url
+                } else if(this.data.attributes?.editorialArtwork?.storeFlowcase){
+                    return this.data.attributes?.editorialArtwork?.storeFlowcase.url
+                }
+                return false;
             },
             getBadges() {
                 return

--- a/src/renderer/views/pages/cider-playlist.ejs
+++ b/src/renderer/views/pages/cider-playlist.ejs
@@ -12,7 +12,7 @@
                  @mouseover.self="minClass(false)">
                 <div class="playlistInfo">
                     <div class="playlist-hero" v-if="hasHero()">
-                        <mediaitem-artwork shadow="none" :url="hasHero()" size="2048" />
+                        <mediaitem-artwork shadow="none" :url="hasHero()" size="2160" />
                     </div>
                     <div class="row">
                         <div class="col-auto flex-center" @mouseover="minClass(false)">

--- a/src/renderer/views/pages/cider-playlist.ejs
+++ b/src/renderer/views/pages/cider-playlist.ejs
@@ -13,10 +13,7 @@
                 <div class="playlistInfo">
                     <div class="playlist-hero" v-if="hasHero()">
                         <mediaitem-artwork shadow="none" :url="hasHero()" size="2160" />
-                        <div class="hero-tint" :style="{ 'position':'absolute', 'top' : '0',
-                        'background-color': '#' + hasHeroObject()?.bgColor ?? '' , // 50%
-                        'opacity': '0.6',
-                        'width':'100%', 'height':'100%'}"></div> 
+                        <div class="hero-tint" :style="{'background-color': '#' + hasHeroObject()?.bgColor ?? ''}"></div> 
                     </div>
                     <div class="row">
                         <div class="col-auto flex-center" @mouseover="minClass(false)">
@@ -117,6 +114,7 @@
                                             spellcheck="false"
                                             :placeholder="$root.getLz('term.search') + '...'"
                                             @input="search()"
+                                            :style="{ '--heroplaceholdercolor': '#' +hasHeroObject()?.textColor4 ?? ''}"
                                             v-model="searchQuery"
                                             class="search-input">
                                     </div>


### PR DESCRIPTION
this basically works but code is spaghetti.

please send help.

**Todo:**

- [ ] make artwork material just a plain color (`bgColor` from editorialArtwork, NOT THE CIDER ONE!), so there won't be some harsh color clashes
- [ ] make the album name, editorial info and buttons text in `textColor1`
- [ ] make the genre text `textColor2`
- [ ] maybe make the search bar placeholder text `textColor3`? (wont be needed if PR 1189 was merged)

here is an image since you guys like them so much:

![a screenshot of the cider interface, showing the album Blue Pop Reverberation by Sangatsu no Phantasia.](https://user-images.githubusercontent.com/32032824/175551075-654c209e-a76a-4826-80ac-ca98d48bb9ca.png)