### PR TITLE
Remove conditional rendering of the heart icon

### DIFF
--- a/src/renderer/views/components/mediaitem-list-item.ejs
+++ b/src/renderer/views/components/mediaitem-list-item.ejs
@@ -67,7 +67,7 @@
                     </template>
                 </div>
             </div>
-            <div class="heart-icon" v-if="!(app.mk.isPlaying && (((app.mk.nowPlayingItem._songId ?? (app.mk.nowPlayingItem.songId ?? app.mk.nowPlayingItem.id ))  == itemId) || (app.mk.nowPlayingItem.id == item.id)))">
+            <div class="heart-icon">
                 <!-- <div class="heart-unfilled" v-if="isLoved == false" :style="{'--url': 'url(./assets/feather/heart.svg)'}" /> -->
                 <div class="heart-filled" v-if="isLoved == true" :style="{'--url': 'url(./assets/feather/heart-fill.svg)'}" />
             </div>


### PR DESCRIPTION
This condition is preventing the heart icon from showing up if the song is playing.

Before:
![Screenshot from 2022-06-26 17-21-54](https://user-images.githubusercontent.com/44944781/175824260-b6045ecb-96ea-4766-8d7d-3e47d86664eb.png)

After:
![Screenshot from 2022-06-26 17-33-00](https://user-images.githubusercontent.com/44944781/175824396-751c20ee-73b8-4a28-b394-51be148af58a.png)


