### PR TITLE
Revert Noto CJK for UI

### DIFF
--- a/src/renderer/style.less
+++ b/src/renderer/style.less
@@ -70,7 +70,7 @@ body {
   background-size: cover;
   background-position: center;
   background: #0000;
-  font-family: "Pretendard Variable", "Noto Sans JP", "Noto Sans KR", "Noto Sans TC", "Noto Sans SC", -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  font-family: "Pretendard Variable", -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
   transition: opacity .10s var(--appleEase);
 }
 


### PR DESCRIPTION
This reverts CJK fonts in the Cider UI to be the system default.

This fixes quite a few problems:
* Some zh_CN glyphs being displayed in Japanese
* Hard-to-read zh_TW/HK glyphs in the sidebar (bold, and they have lots of strokes)

The fonts for lyrics remain unchanged.