### PR TITLE
Change No Lyrics Message in Full Screen Player

### DIFF
--- a/src/i18n/en_OWO.json
+++ b/src/i18n/en_OWO.json
@@ -136,7 +136,7 @@
   "term.amLive": "Appwe Music Wive",
   "term.language": "Wanguage",
   "term.funLanguages": "Fun",
-  "term.noLyrics": "Woading... / Wywics nyot found./ Instwumentaw.",
+  "term.noLyrics": ">w< Sowwy Wowwy.. N-Nyo Wywics Avaiwabwe",
   "term.copyright": "Copywight",
   "term.rightsReserved": "Aww Wights Wesewved.",
   "term.sponsor": "Sponsow this pwoject",

--- a/src/i18n/en_PISS.json
+++ b/src/i18n/en_PISS.json
@@ -103,7 +103,7 @@
   "term.recentStations": "recent pisses",
   "term.language": "piss around the world",
   "term.funLanguages": "piss languages",
-  "term.noLyrics": "piss…",
+  "term.noLyrics": "out of piss...",
   "term.copyright": "copypiss",
   "term.rightsReserved": "all piss reserved.",
   "term.sponsor": "piss on Cider",

--- a/src/i18n/en_US.json
+++ b/src/i18n/en_US.json
@@ -137,7 +137,7 @@
   "term.live": "LIVE",
   "term.language": "Language",
   "term.funLanguages": "Fun",
-  "term.noLyrics": "Loading... / Lyrics not found./ Instrumental.",
+  "term.noLyrics": "Instrumental Track, No Lyrics.",
   "term.copyright": "Copyright",
   "term.rightsReserved": "All Rights Reserved.",
   "term.sponsor": "Sponsor this project",

--- a/src/i18n/en_US.json
+++ b/src/i18n/en_US.json
@@ -137,7 +137,7 @@
   "term.live": "LIVE",
   "term.language": "Language",
   "term.funLanguages": "Fun",
-  "term.noLyrics": "Instrumental Track, No Lyrics.",
+  "term.noLyrics": "Instrumental Track / No Lyrics.",
   "term.copyright": "Copyright",
   "term.rightsReserved": "All Rights Reserved.",
   "term.sponsor": "Sponsor this project",

--- a/src/i18n/hi_IN.json
+++ b/src/i18n/hi_IN.json
@@ -101,7 +101,7 @@
   "term.recentStations": "Recent Stations",
   "term.language": "Language",
   "term.funLanguages": "Fun",
-  "term.noLyrics": "Loading... / Lyrics not found./ Instrumental.",
+  "term.noLyrics": "Instrumental Track, No Lyrics.",
   "term.copyright": "Copyright",
   "term.rightsReserved": "All Rights Reserved.",
   "term.sponsor": "Sponsor this project",

--- a/src/i18n/hi_IN.json
+++ b/src/i18n/hi_IN.json
@@ -101,7 +101,7 @@
   "term.recentStations": "Recent Stations",
   "term.language": "Language",
   "term.funLanguages": "Fun",
-  "term.noLyrics": "Instrumental Track, No Lyrics.",
+  "term.noLyrics": "Instrumental Track / No Lyrics.",
   "term.copyright": "Copyright",
   "term.rightsReserved": "All Rights Reserved.",
   "term.sponsor": "Sponsor this project",

--- a/src/i18n/source/en_US.json
+++ b/src/i18n/source/en_US.json
@@ -136,7 +136,7 @@
   "term.amLive": "Apple Music Live",
   "term.language": "Language",
   "term.funLanguages": "Fun",
-  "term.noLyrics": "Instrumental Track, No Lyrics.",
+  "term.noLyrics": "Instrumental Track / No Lyrics.",
   "term.copyright": "Copyright",
   "term.rightsReserved": "All Rights Reserved.",
   "term.sponsor": "Sponsor this project",

--- a/src/i18n/source/en_US.json
+++ b/src/i18n/source/en_US.json
@@ -136,7 +136,7 @@
   "term.amLive": "Apple Music Live",
   "term.language": "Language",
   "term.funLanguages": "Fun",
-  "term.noLyrics": "Loading... / Lyrics not found./ Instrumental.",
+  "term.noLyrics": "Instrumental Track, No Lyrics.",
   "term.copyright": "Copyright",
   "term.rightsReserved": "All Rights Reserved.",
   "term.sponsor": "Sponsor this project",


### PR DESCRIPTION
This PR modifies the localization files to change the text that shows in the full screen player when lyrics for a track are not found. The small change improves conciseness, in addition, I personally find that the existing text feels weird and somewhat out of place. This is 100% a nitpick change.

Affected localization:
en_US, en_US, hi_IN (?)
as well as en_PISS and en_OWO (Translated using https://aqua-lzma.github.io/OwOify/)