### PR TITLE
Support a custom port number via optional CIDER_PORT variable

### DIFF
--- a/src/main/base/browserwindow.ts
+++ b/src/main/base/browserwindow.ts
@@ -368,7 +368,8 @@ export class BrowserWindow {
      * @yields {object} Electron browser window
      */
     async createWindow(): Promise<Electron.BrowserWindow> {
-        this.clientPort = await getPort({ port: 9000 });
+        const envPort = process.env?.CIDER_PORT || '9000'
+        this.clientPort = await getPort({ port: parseInt(envPort, 10) || 9000 });
         BrowserWindow.verifyFiles();
         this.StartWatcher(utils.getPath('themes'));
 


### PR DESCRIPTION
If port 9000 was already in use, then the Cider port number would be randomized. However when a port number is randomized I noticed that I needed to log back in. Possibly authorization is tied to the port number?

This was not ideal, so I have added an optional environment variable to use a custom port number. It defaults to 9000 if the custom port number is not present or is invalid.