### PR TITLE
README download links fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@
 * [Documentation](https://docs.cider.sh)
 * [Request Feature](https://github.com/ciderapp/Cider/discussions/new?category=feature-request)
 * [Report Bug](https://github.com/ciderapp/Cider/issues/new?assignees=&labels=bug&template=bug_report.md&title=%5BBUG%5D+)
-* [**View The Releases**](https://github.com/ciderapp/Cider/releases/latest)
+* [**View The Releases**](https://github.com/ciderapp/cider-releases/releases/latest)
 
 ### Install Sources
-[![Get it from Github](https://img.shields.io/badge/Get_It_From_GitHub-100000?style=for-the-badge&logo=github&logoColor=white)](https://github.com/ciderapp/cider/releases/latest)
+[![Get it from Github](https://img.shields.io/badge/Get_It_From_GitHub-100000?style=for-the-badge&logo=github&logoColor=white)](https://github.com/ciderapp/cider-releases/releases/latest)
 
 [![Get it from the Microsoft Store](https://img.shields.io/badge/Get_It_From_The_Microsoft_Store-100000?style=for-the-badge&logo=microsoft)](https://www.microsoft.com/store/apps/9P21XJ9D9G66)
 


### PR DESCRIPTION
This pull request fixes the download links within README.

**Before:** README links points to ciderapp/Cider's release page  
**After:** README links points to ciderapp/cider-releases's release page