### PR TITLE
Add ratings, library change to web remote

### DIFF
--- a/src/web-remote/style.css
+++ b/src/web-remote/style.css
@@ -838,6 +838,15 @@ input[type=range].web-slider::-webkit-slider-runnable-track {
     cursor: pointer;
 }
 
+.context-menu .context-menu-item:disabled {
+    cursor: default;
+    filter: brightness(125%);
+}
+
+.context-menu .context-menu-item:active:disabled {
+    filter: brightness(125%);
+}
+
 .context-menu .context-menu-item:active {
     filter: brightness(75%);
 }

--- a/src/web-remote/views/index.ejs
+++ b/src/web-remote/views/index.ejs
@@ -130,8 +130,8 @@
                                         {{ player.currentMediaItem.artistName }}
                                     </div>
                                 </div>
-                                <div class="col-auto nopadding player-more-container" v-if="false" style="">
-                                    <button @click="player.songActions = true;" class="player-more-button">...</button>
+                                <div class="col-auto nopadding player-more-container" style="">
+                                    <button @click="openSongMenu()" class="player-more-button">...</button>
                                 </div>
                             </div>
                         </div>
@@ -525,7 +525,8 @@
 
                     </div>
                     <div class="md-body context-menu-body">
-                        <button class="context-menu-item context-menu-item--left" v-if="false">
+                        <button class="context-menu-item context-menu-item--left" v-if="!player.status.inLibrary"
+                            @click="toLibrary(true)">
                             <div class="row">
                                 <div class="col">
                                     Add To Library
@@ -535,7 +536,19 @@
                                 </div>
                             </div>
                         </button>
-                        <button class="context-menu-item context-menu-item--left" v-if="false">
+                        <button class="context-menu-item context-menu-item--left" v-if="player.status.inLibrary"
+                            @click="toLibrary(false)">
+                            <div class="row">
+                                <div class="col">
+                                    Remove From Library
+                                </div>
+                                <div class="col-auto">
+                                    ➖
+                                </div>
+                            </div>
+                        </button>
+                        <button class="context-menu-item context-menu-item--left" :disabled="player.status.rating === 1"
+                            @click="rate(1)">
                             <div class="row">
                                 <div class="col">
                                     Love
@@ -545,7 +558,29 @@
                                 </div>
                             </div>
                         </button>
-                        <button class="context-menu-item context-menu-item--left">
+                        <button class="context-menu-item context-menu-item--left" :disabled="player.status.rating === 0"
+                            @click="rate(0)">
+                            <div class="row">
+                                <div class="col">
+                                    Remove Rating
+                                </div>
+                                <div class="col-auto">
+                                    ❌
+                                </div>
+                            </div>
+                        </button>
+                        <button class="context-menu-item context-menu-item--left"
+                            :disabled="player.status.rating === -1" @click="rate(-1)">
+                            <div class="row">
+                                <div class="col">
+                                    Dislike
+                                </div>
+                                <div class="col-auto">
+                                    👎
+                                </div>
+                            </div>
+                        </button>
+                        <button class="context-menu-item context-menu-item--left" v-if="false">
                             <div class="row">
                                 <div class="col">
                                     Share
@@ -555,7 +590,7 @@
                                 </div>
                             </div>
                         </button>
-                        <button class="context-menu-item context-menu-item--left">
+                        <button class="context-menu-item context-menu-item--left" v-if="false">
                             <div class="row">
                                 <div class="col">
                                     Open in {{ musicAppVariant() }}


### PR DESCRIPTION
Hope I'm not being a pain. I like the web remote, but one thing that I've wanted to do is like/dislike a song, and add it to my library. This PR seeks to add these features bu expanding on the existing song actions menu, and implementing the necessary socket communication. 

![ratings-menu](https://user-images.githubusercontent.com/17521368/179150706-b34bae6c-58e6-433e-a310-4974e719fac9.png)

Clicking on one of Love/Dislike will then make that option lighter and disabled. Clicking on Add to library will toggle remove from library (although it may take a while for Cider to actually recognize it's removed because apple .-.)

I also commented out a few of the console.log, because they pollute the console.