### PR TITLE
Add gradient to lyric-footer

### DIFF
--- a/src/renderer/style.less
+++ b/src/renderer/style.less
@@ -1815,7 +1815,7 @@ input[type="range"].web-slider.display--small::-webkit-slider-thumb {
   position       : absolute;
   z-index        : 1000;
   opacity        : 1;
-  background     : rgba(30, 30, 30, 0.8);
+  background-image: linear-gradient(180deg, transparent, rgba(30, 30, 30, 0.8));
   justify-content: center;
   align-items    : center;
   display        : none;


### PR DESCRIPTION
Made changes to the background of the `Fullscreen View` button. It now has a gray-to-transparent gradient. Looks more fitting
Preview:
* Old
![old](https://user-images.githubusercontent.com/79590499/180646000-43e901c8-b30b-4a76-9f9e-1de776088212.png)
* New
![new](https://user-images.githubusercontent.com/79590499/180646135-88c80343-08f7-4ff6-bca1-47eb865f966f.png)

