### PR TITLE
Adds the Chocolatey package as a way to install Cider

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@
 
 [![Get it from Windows Package Manager](https://custom-icon-badges.herokuapp.com/badge/Get_It_via_Winget_(Nightly)_-100000?style=for-the-badge&logo=winstall)](https://winstall.app/apps/CiderCollective.Cider)
 
+[![Get it from Chocolatey Package Manager](https://custom-icon-badges.herokuapp.com/badge/Get_It_via_Chocolatey_-100000?style=for-the-badge&logo=chocolatey)](https://community.chocolatey.org/packages/cider)
+
 <!--
 [![Get it from Windows Package Manager](https://custom-icon-badges.herokuapp.com/badge/Get_It_via_Winget_(Nightly)_-100000?style=for-the-badge&logo=winstall)](https://winstall.app/apps/CiderCollective.Cider.Nightly)
 -->


### PR DESCRIPTION
Hi @Cider_devs,

I have created this Pull Request because I have resolved this [request for a Chocolatey package](https://github.com/chocolatey-community/chocolatey-package-requests/issues/1298) and now, we can install **cider** using Chocolatey ([the package is available here](https://community.chocolatey.org/packages/cider)).

For now, only the version `1.5.1` is available on Chocolatey, and the version `1.5.4` is for now waiting for the Chocolatey moderators to be reviewed.

