### PR TITLE
Fix hover titles for album names

### DIFF
--- a/src/renderer/views/components/mediaitem-list-item.ejs
+++ b/src/renderer/views/components/mediaitem-list-item.ejs
@@ -62,16 +62,18 @@
                 <div class="title text-overflow-elipsis" :title="item.attributes.name">
                     {{ item.attributes.name }}
                 </div>
-                <div class="subtitle text-overflow-elipsis" :title="item.attributes.artistName"
+                <div class="subtitle text-overflow-elipsis"
                      style="-webkit-box-orient: horizontal;">
                     <template v-if="item.attributes.artistName">
                         <div class="artist item-navigate text-overflow-elipsis"
+                             :title="item.attributes.artistName"
                              @click="app.searchAndNavigate(item,'artist')">
                             {{ item.attributes.artistName }}
                         </div>
                         <template v-if="item.attributes.albumName">&nbsp;—&nbsp;</template>
                         <template v-if="item.attributes.albumName">
                             <div class="artist item-navigate text-overflow-elipsis"
+                                 :title="item.attributes.albumName"
                                  @click="app.searchAndNavigate(item,'album')">
                                 {{ item.attributes.albumName }}
                             </div>


### PR DESCRIPTION
This PR fixes #788.

![Cursor hovering over the text "LOVE ALL SERVE ALL", with hover titles showing the same.](https://user-images.githubusercontent.com/32032824/184646001-c409ea0b-9507-45a5-856f-6a3be8ebd67b.png)