### PR TITLE
Added scripts to produce separated macOS builds for different architectures

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
     "msft": "npm run build && electron-builder -c msft-package.json",
     "mstest": "npm run build && electron-builder -c msft-test.json",
     "postinstall": "electron-builder install-app-deps",
-    "prettier": "npx prettier --write '**/*.{js,json,ts,css,less}'"
+    "prettier": "npx prettier --write '**/*.{js,json,ts,css,less}'",
+    "slim-build:macarm": "ditto --arch arm64 ./dist/mac-universal/Cider.app ./dist/mac-universal/arm64/Cider.app",
+    "slim-build:macintel": "ditto --arch x86_64 ./dist/mac-universal/Cider.app ./dist/mac-universal/x86_x64/Cider.app"
   },
   "dependencies": {
     "@sentry/electron": "^4.0.0",


### PR DESCRIPTION
Cider is indeed an electron app which comes with the cost of fat, massive binaries.  With the recent releases of Apple Silicon machines, Apple decided that universal binaries would be a good idea to solve the problem of confusing customers about the two CPU architectures.  However, one of the caveats of universal binaries is bigger binary sizes because universal builds usually contain both Intel and Apple Silicon code despite a Mac would not need both the Intel and AS code which only has to run one of the two codebases.  I would suggest Cider start releasing separated macOS builds for both Intel and AS architectures to slim down the size of the Cider app.  The scripts use the `ditto` which does not require rebuilding for each architecture but rather separates the universal build into two separate builds in a matter of seconds, which would be a more viable solution.  A 500MB music player app?  No more.