### PR TITLE
Change Album Search and Pagination Layout

### DIFF
--- a/src/renderer/less/pages.css
+++ b/src/renderer/less/pages.css
@@ -569,6 +569,23 @@
   }
 }
 /* Album / Playlist Page */
+.album-header {
+  position: sticky;
+  left: 0;
+  z-index: 6;
+  padding: 0px 2em;
+  backdrop-filter: blur(32px);
+  background: rgba(0, 0, 0, 0.25);
+  top: var(--navigationBarHeight);
+  --bs-gutter-x: 4rem;
+  --bs-gutter-y: 0;
+  display: flex;
+  flex-wrap: wrap;
+  margin-top: calc(-1 * var(--bs-gutter-y));
+  margin-right: calc(-0.5 * var(--bs-gutter-x));
+  margin-left: calc(-0.5 * var(--bs-gutter-x));
+  border-bottom: 1px solid rgba(200, 200, 200, 0.05);
+}
 .playlist-page {
   --bgColor: transparent;
   padding: 0px;

--- a/src/renderer/less/pages.less
+++ b/src/renderer/less/pages.less
@@ -695,6 +695,23 @@
 }
 
 /* Album / Playlist Page */
+.album-header {
+  position: sticky;
+  left: 0;
+  z-index: 6;
+  padding: 0px 2em;
+  backdrop-filter: blur(32px);
+  background: rgba(0, 0, 0, 0.25);
+  top: var(--navigationBarHeight);
+  --bs-gutter-x: 4rem;
+  --bs-gutter-y: 0;
+  display: flex;
+  flex-wrap: wrap;
+  margin-top: calc(-1 * var(--bs-gutter-y));
+  margin-right: calc(-0.5 * var(--bs-gutter-x));
+  margin-left: calc(-0.5 * var(--bs-gutter-x));
+  border-bottom: 1px solid rgba(200, 200, 200, 0.05);
+}
 .playlist-page {
   --bgColor: transparent;
   padding: 0px;

--- a/src/renderer/views/pages/library-albums.ejs
+++ b/src/renderer/views/pages/library-albums.ejs
@@ -10,7 +10,7 @@
                         :aria-label="app.getLz('menubar.options.reload')"><%- include('../svg/redo.svg') %></button>
             </div>
         </div>
-        <div class="row">
+        <div class="album-header">
             <div class="col" style="padding:0;">
                 <div class="search-input-container" style="width:100%;margin: 16px 0;">
                     <div class="search-input--icon"></div>
@@ -63,15 +63,15 @@
                     </div>
                 </div>
             </div>
+            <pagination
+              :length="app.library.albums.displayListing.length"
+              :pageSize="pageSize"
+              :scroll="prefs.scroll"
+              scrollSelector="#app-content"
+              @onRangeChange="onRangeChange"
+              style="margin-bottom: 0;"
+            />
         </div>
-        <pagination
-                :length="app.library.albums.displayListing.length
-            "
-                :pageSize="pageSize"
-                :scroll="prefs.scroll"
-                scrollSelector="#app-content"
-                @onRangeChange="onRangeChange"
-        />
         <div class="well">
             <div class="albums-square-container">
                 <div>


### PR DESCRIPTION
This PR:
* Makes the search and filter options, and pagination buttons in one line. Looks more fitting and alike library-songs.
* Makes them sticky, thus no need to scroll back up to use the search bar, et cetera.

Preview:
![image](https://user-images.githubusercontent.com/79590499/187288909-03c59575-19c3-4663-af53-2b87238b9133.png)