### PR TITLE
Support for opening iTunes and Apple Music links

### DIFF
--- a/src/main/base/app.ts
+++ b/src/main/base/app.ts
@@ -232,7 +232,7 @@ export class AppEvents {
 
         startArgs.forEach((arg) => {
           console.log(arg);
-          if (arg.includes("cider://")) {
+          if (arg.includes("cider://") || arg.includes("itms://") || arg.includes("itmss://") || arg.includes("music://") || arg.includes("musics://")) {
             console.debug("[InstanceHandler] (second-instance) Link detected with " + arg);
             this.LinkHandler(arg);
           } else if (arg.includes("--force-quit")) {


### PR DESCRIPTION
This really simple change allows users to not only open `cider://` URLs in the app, but also native iTunes `itms://` and `itmss://` as well as native Apple Music `music://` and `musics://` links.

While the app is registered by default to handle these URLs (at least on Windows), Cider refused to accept any links if they were not specifically `cider://` links. Since the `cider://` URL format is pretty much the same as any of the native URL's formats, Cider already has a parser for these URLs. This single-line change only tells it to apply its parsing and opening logic to the native URL prefixes as well.