### PR TITLE
fix discord rpc

### DIFF
--- a/src/i18n/en_US.json
+++ b/src/i18n/en_US.json
@@ -530,7 +530,7 @@
   "settings.option.connectivity.discordRPC.clientName": "Client Name",
   "settings.option.connectivity.discordRPC.clearOnPause": "Clear Discord Rich Presence on Pause",
   "settings.option.connectivity.discordRPC.hideButtons": "Hide buttons on Discord Rich Presence",
-  "settings.option.connectivity.discordRPC.showSongLink": "Show Song.link button on Discord Rich Presence",
+  "settings.option.connectivity.discordRPC.showSongLink": "Show Song.link button instead of Apple Music button on Discord Rich Presence",
   "settings.option.connectivity.discordRPC.hideTimestamp": "Hide timestamp on Discord Rich Presence",
   "settings.option.connectivity.discordRPC.detailsFormat": "Details Format",
   "settings.option.connectivity.discordRPC.stateFormat": "State Format",

--- a/src/main/plugins/discordrpc.ts
+++ b/src/main/plugins/discordrpc.ts
@@ -237,8 +237,7 @@ export default class DiscordRPC {
     if (!this._utils.getStoreValue("connectivity.discord_rpc.hide_buttons")) {
       activity.buttons = [
         { label: "Listen on Cider", url: attributes.url.cider },
-        { label: "View on Apple Music", url: attributes.url.appleMusic },
-        ...(showSongLink ? [{ label: "Song.link", url: "https://song.link/i/" + attributes.songId }] : []),
+        ... showSongLink ? [{ label: "View on other platforms", url: 'https://song.link/i/' + attributes.songId }] : [{ label: "View on Apple Music", url: attributes.url.appleMusic }]
       ]; //To change attributes.url => preload/cider-preload.js
     }
 


### PR DESCRIPTION
this fixes https://github.com/ciderapp/Cider/pull/1435 because discord rpc does not support 3 buttons.

it now shows "view on other platforms" with the song.link link instead of "view on apple music"