### PR TITLE
Fix album track order for date added sorting

### DIFF
--- a/src/renderer/main/vueapp.js
+++ b/src/renderer/main/vueapp.js
@@ -2531,6 +2531,11 @@ const app = new Vue({
           } else if (prefs.sort === "dateAdded") {
             aa = a.relationships?.albums?.data[0]?.attributes?.dateAdded;
             bb = b.relationships?.albums?.data[0]?.attributes?.dateAdded;
+            // if dateAdded is equal, an entire album was added at once, so sorting by track number (in reverse order because lower track number should be above in descending mode)
+            if (aa === bb) {
+              aa = b.attributes.trackNumber;
+              bb = a.attributes.trackNumber;
+            }
           } else if (prefs.sort === "artistName") {
             if (a.relationships?.artists?.data[0]?.id === b.relationships?.artists?.data[0]?.id) {
               aa = a.attributes.albumName;


### PR DESCRIPTION
Currently when sorting by date added, the order within albums is incorrect, because the timestamp is the same for tracks that are added as part of an album. Falling back to sorting by track number solves this.