### PR TITLE
Use sticky position instead of absolute

### DIFF
--- a/src/renderer/views/components/sidebar.ejs
+++ b/src/renderer/views/components/sidebar.ejs
@@ -193,7 +193,7 @@
                 >
                 </sidebar-playlist>
             </template>
-            <div v-if="app.cfg.visual.artworkDisplayLayout == 'sidebar'" @click.stop="switchArtworkDisplayLayout()" class="artwork" id="artworkLCD" style="position:absolute;bottom:0px">
+            <div v-if="app.cfg.visual.artworkDisplayLayout == 'sidebar'" @click.stop="switchArtworkDisplayLayout()" class="artwork" id="artworkLCD" style="position:sticky;bottom:0px">
               <mediaitem-artwork :url="$root.currentArtUrl"></mediaitem-artwork>
             </div>
         </div>


### PR DESCRIPTION
Use sticky position on expanded artwork instead of absolute, this allows users to scroll and view content that would be hidden behind the expanded artwork. It also aligns the artwork perfectly in centre.