### PR TITLE
Add transparency option to linux

### DIFF
--- a/src/main/base/browserwindow.ts
+++ b/src/main/base/browserwindow.ts
@@ -428,8 +428,12 @@ export class BrowserWindow {
         }
         break;
       case "linux":
-        this.options.backgroundColor = "#1E1E1E";
         this.options.autoHideMenuBar = true;
+        if (!(utils.getStoreValue("visual.transparent") ?? false)) {
+          this.options.backgroundColor = "#1E1E1E";
+        } else {
+          this.options.transparent = true;
+        }
         if (utils.getStoreValue("visual.nativeTitleBar")) {
           this.options.titleBarStyle = "visible";
           this.options.frame = true;

--- a/src/renderer/views/components/settings-window.ejs
+++ b/src/renderer/views/components/settings-window.ejs
@@ -1490,7 +1490,7 @@
                                     </div>
                                 </div>
 
-                                <div class="md-option-line update-check" v-if="app.platform === 'win32'">
+                                <div class="md-option-line update-check" v-if="app.platform === 'win32' || app.platform === 'linux'">
                                     <div class="md-option-segment">
                                         {{$root.getLz('settings.option.visual.transparent')}}<br>
                                         <small>({{$root.getLz('settings.option.visual.transparent.description')}})</small>


### PR DESCRIPTION
Allows Linux users to set transparency by adding the toggle to advanced settings and by adding the appropriate Electron app configuration values.

Example:
![Screenshot](https://i.imgur.com/wRRIwH5.png)