### PR TITLE
steam-deck: update steam deck electron version to 22.1.0

### DIFF
--- a/steam-deck.json
+++ b/steam-deck.json
@@ -1,7 +1,7 @@
 {
-  "electronVersion": "18.3.12",
+  "electronVersion": "22.1.0",
   "electronDownload": {
-    "version": "18.3.12+wvcus",
+    "version": "22.1.0+wvcus",
     "mirror": "https://github.com/castlabs/electron-releases/releases/download/v"
   },
   "appId": "cider",


### PR DESCRIPTION
Updates the electron version to the latest version in the steam deck file