### PR TITLE
fix SteamOS check

### DIFF
--- a/src/main/base/app.ts
+++ b/src/main/base/app.ts
@@ -94,7 +94,7 @@ export class AppEvents {
     if (process.platform === "linux") {
       app.commandLine.appendSwitch("disable-features", "MediaSessionService");
 
-      if (os.version().indexOf("SteamOS")) {
+      if (os.version().includes("SteamOS")) {
         app.commandLine.appendSwitch("enable-features", "UseOzonePlatform");
         app.commandLine.appendSwitch("ozone-platform", "x11");
       }


### PR DESCRIPTION
Fixes #1624 and #1514.

I believe the bug works the following way: [`indexOf` returns `-1`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/indexOf#return_value) if the substring is not found, that becomes `true` after cast to boolean. This results in overriding `--enable-features=UseOzonePlatform` and `--ozone-platform` flags when running on linux. Please note that I have zero experience with js, but the bug is pretty obvious and this fix allows me to run the app natively on sway.