### PR TITLE
Implement MPRIS Raise method to allow showing the window

### DIFF
--- a/src/main/base/app.ts
+++ b/src/main/base/app.ts
@@ -280,8 +280,18 @@ export class AppEvents {
     this.tray.setToolTip(app.getName());
     this.setTray(false);
 
-    this.tray.on("double-click", () => {
+    this.tray.on("double-click", () => {  // supports windows and mac only
       if (utils.getWindow()) {
+        if (utils.getWindow().isVisible()) {
+          utils.getWindow().focus();
+        } else {
+          utils.getWindow().show();
+        }
+      }
+    });
+
+    this.tray.on("click", () => {
+      if (utils.getWindow() && process.platform === "linux") {  // use single click to open when double doesn't work
         if (utils.getWindow().isVisible()) {
           utils.getWindow().focus();
         } else {

--- a/src/main/plugins/mpris.ts
+++ b/src/main/plugins/mpris.ts
@@ -74,6 +74,10 @@ export default class mpris {
     player.on("volume", (volume: string) => {
       renderer.executeJavaScript(`app.mk.volume = ${parseFloat(volume)}`);
     });
+    player.on("raise", () => {
+      mpris.utils.getWindow().show();
+      mpris.utils.getWindow().focus();
+    });
 
     mpris.utils.getIPCMain().on("mpris:playbackTimeDidChange", (event: any, time: number) => {
       player.getPosition = () => time;


### PR DESCRIPTION
Cider currently advertises MPRIS Raise method capability (CanRaise returns true) but ignores Raise calls. This PR just adds the expected behaviour (window is shown and focused). Thank you for all the work on Cider, by the way!